### PR TITLE
Completes UNB-1376 - Client now passes SDK version metadata along with requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import pathlib
 
 import pkg_resources
 from setuptools import find_packages, setup
+from distutils.util import convert_path
 
 with pathlib.Path("requirements.txt").open() as requirements_txt:
     install_requires = [
@@ -11,10 +12,14 @@ with pathlib.Path("requirements.txt").open() as requirements_txt:
         for requirement in pkg_resources.parse_requirements(requirements_txt)
     ]
 
+main_ns = {}
+ver_path = convert_path('unboxapi/version.py')
+with open(ver_path) as ver_file:
+    exec(ver_file.read(), main_ns)
 
 setup(
     name="unboxapi",
-    version="0.0.0",
+    version=main_ns['__version__'],
     description="The official Python client library for Unbox, the Testing and Debugging Platform for AI",
     url="https://github.com/unboxai/unboxapi-python-client",
     author="Unbox",

--- a/unboxapi/api.py
+++ b/unboxapi/api.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
 
 from .exceptions import ExceptionMap, UnboxException
+from .version import __version__
 
 # UNBOX_ENDPOINT = "https://api-staging.unbox.ai/api"
 UNBOX_ENDPOINT = "http://localhost:8080/api"
@@ -19,6 +20,10 @@ HTTP_TOTAL_RETRIES = 3  # Number of total retries
 HTTP_RETRY_BACKOFF_FACTOR = 2  # Wait 1, 2, 4 seconds between retries
 HTTP_STATUS_FORCE_LIST = [408, 429] + list(range(500, 531))
 HTTP_RETRY_ALLOWED_METHODS = frozenset({"GET", "POST"})
+
+CLIENT_METADATA = {
+    "version": __version__
+}
 
 
 class Api:
@@ -60,7 +65,7 @@ class Api:
 
         try:
             params = params or {}
-
+            params.update(CLIENT_METADATA)
             res = https.request(
                 method=method,
                 url=url,

--- a/unboxapi/version.py
+++ b/unboxapi/version.py
@@ -1,0 +1,3 @@
+# Define the SDK version here so that both the setup.py and the interal package can have access to this value.
+# See https://stackoverflow.com/questions/2058802
+__version__ = '0.0.1'


### PR DESCRIPTION
# Summary

We want the backend to respond with errors based on the version metadata we pass to it. This change just allows for the version information to be passed along to the backend without harming how setup.py works.

Note that I followed https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package to get this working.

# Testing

Logged the version information in the backend to ensure that the version metadata was being passed to it as expected.

