### PR TITLE
Completes UNB-2253 - XGBoost native support

### DIFF
--- a/unboxapi/models.py
+++ b/unboxapi/models.py
@@ -25,6 +25,8 @@ class ModelType(Enum):
     pytorch = "PytorchModelArtifact"
     #: For models built with `TensorFlow <https://www.tensorflow.org/>`_.
     tensorflow = "TensorflowSavedModelArtifact"
+    #: For models built with `XGBoost <https://xgboost.readthedocs.io>`_.
+    xgboost = "XgboostModelArtifact"
     #: For models built with `Hugging Face transformers <https://huggingface.co/docs/transformers/index>`_.
     transformers = "TransformersModelArtifact"
     #: For models built with `Keras <https://keras.io/>`_.


### PR DESCRIPTION
Added support for XGBoost.

## Pending:
Inclusion of notebook example. On the notebook, it is important to highlight the need to use the native XGBoost library (which returns a `xgboost.core.Booster` object instead of a `xgboost.sklearn.XGBClassifier` object), and not the Sklearn API.
