### PR TITLE
Cid/dataset versioning

### DIFF
--- a/unboxapi/__init__.py
+++ b/unboxapi/__init__.py
@@ -437,7 +437,6 @@ class UnboxClient(object):
                     endpoint = f"projects/{project_id}/ml-models"
                     payload = dict(
                         name=name,
-                        projectId=project_id,
                         description=description,
                         classNames=class_names,
                         taskType=task_type.value,
@@ -641,7 +640,6 @@ class UnboxClient(object):
             )
         endpoint = f"projects/{project_id}/datasets"
         payload = dict(
-            projectId=project_id,
             commitMessage=commit_message,
             taskType=task_type.value,
             classNames=class_names,


### PR DESCRIPTION
This is the Python API accompanying PR for [#198](https://github.com/unboxai/unbox/pull/198) on the `unbox` repo.

## Summary

Removes the dataset `name` from `add_dataset` and `add_dataframe` and renames `description` to `commit_message`.

Furthermore, removed the `projectId` from the payload on model / dataset uploads. It is not necessary to pass it as part of the request body, since the endpoint paths have the `projectId`.