### PR TITLE
Rishab/unb 2434 add urls to project dataset model in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+# Fixed
+
+* Fixed link to project page when loading / creating a project.
+
+# Changed
+
+* Removed links when uploading dataset and models. Just the project link is appropriate.
+
 ## [0.3.0a1]
 
 # Changed

--- a/unboxapi/__init__.py
+++ b/unboxapi/__init__.py
@@ -700,9 +700,7 @@ class UnboxClient(object):
                     )
         os.remove("template_model.py")
 
-        print(
-            f"Uploading model to Unbox! Check out https://unbox.ai/models to have a look!"
-        )
+        print(f"Adding your model to Unbox! Check out the project page to have a look.")
         return Model(modeldata)
 
     def add_dataset(
@@ -972,9 +970,7 @@ class UnboxClient(object):
             featureNames=feature_names,
             categoricalFeatureNames=categorical_feature_names,
         )
-        print(
-            f"Uploading dataset to Unbox! Check out https://unbox.ai/datasets to have a look!"
-        )
+        print(f"Adding your dataset to Unbox! Check out the project page to have a look.")
         return Dataset(
             self.upload(
                 endpoint=endpoint,


### PR DESCRIPTION
### Summary

The URL printed when creating projects / models / datasets was a placeholder. This adds the client-side changes needed to print the correct URL. The related server side PR is [here](https://github.com/unboxai/unbox/pull/226).

### Testing

I created a project and clicked the link printed.