### PR TITLE
Completes UNB-2543 - Fix bug with dataset validation for text datasets

### DIFF
--- a/unboxapi/schemas.py
+++ b/unboxapi/schemas.py
@@ -174,14 +174,3 @@ class DatasetSchema(Schema):
             raise ValidationError(
                 "`text_column_name` not specified for text classification task. Must specify `text_column_name` for TextClassification `task_type`."
             )
-        elif data["feature_names"] and data["text_column_name"]:
-            if data["task_type"] == "tabular-classification":
-                raise ValidationError(
-                    f"`feature_names` and `text_column_name` being specified. For `task_type` TabularClassification"
-                    + ", only `feature_names` should be passed as argument."
-                )
-            elif data["task_type"] == "text-classification":
-                raise ValidationError(
-                    f"`feature_names` and `text_column_name` being specified. For `task_type` TextClassification"
-                    + ", only `text_column_name` should be passed as argument."
-                )


### PR DESCRIPTION
## Summary

Due to the way we handle the dataset upload payload for NLP, there was a problem with one of the dataset validations I wrote in the past. 

For NLP, before building the payload, we do `feature_names.append(text_column_name)` (`__init__.py`, line 926). As a consequence, even though we have a text classification task, we have both `text_column_name` and `feature_names` as not null. 

The problem is that I had introduced a validation that raised an error if for a given task type, both `text_column_name` and `feature_names` were defined. 

This validation was failing only if we ran the cell where we upload the dataset twice, without restarting the notebook kernel between runs. The first time, `feature_names` was still an empty list and the validation passed. However, on the second run, due to the line specified above, `feature_names = ['text']`, which made the validation fail.

I had encountered this bug before and commented on the original error handling PR (PR #30), but hadn't realized it was happening only when running the cells twice. 

## Testing

Locally, uploading multiple sentiment analysis dataset versions without restarting the notebook kernel.