### PR TITLE
Fix bug with explainability tokenizer validation

### DIFF
--- a/unboxapi/__init__.py
+++ b/unboxapi/__init__.py
@@ -597,30 +597,31 @@ class UnboxClient(object):
                 ) from None
 
         # explainability tokenizer
-        if not isinstance(explainability_tokenizer, Callable):
-            raise UnboxValidationError(
-                f"- `{explainability_tokenizer}` specified as `explainability_tokenizer` is not callable. \n"
-            ) from None
-
-        if model_type != ModelType.custom:
-            try:
-                if task_type in [TaskType.TextClassification]:
-                    test_input = [
-                        "Unbox is great!",
-                        "Let's see if this function is ready for some error analysis",
-                    ]
-                    with HidePrints():
-                        function(model, test_input, **kwargs)
-            except Exception as e:
-                exception_stack = "".join(
-                    traceback.format_exception(type(e), e, e.__traceback__)
-                )
-                raise UnboxResourceError(
-                    context="There is an issue with the specified `explainability_tokenizer`. \n",
-                    message=f"It is failing with the following error: \n{exception_stack}",
-                    mitigation="Make sure your `explainability_tokenizer` receives a list of sentences as input and returns a list of lists of tokens "
-                    + "as output.  Additionally, you may find it useful to debug it on the Jupyter notebook, to ensure it is working correctly before uploading it.",
+        if explainability_tokenizer:
+            if not isinstance(explainability_tokenizer, Callable):
+                raise UnboxValidationError(
+                    f"- `{explainability_tokenizer}` specified as `explainability_tokenizer` is not callable. \n"
                 ) from None
+
+            if model_type != ModelType.custom:
+                try:
+                    if task_type in [TaskType.TextClassification]:
+                        test_input = [
+                            "Unbox is great!",
+                            "Let's see if this function is ready for some error analysis",
+                        ]
+                        with HidePrints():
+                            function(model, test_input, **kwargs)
+                except Exception as e:
+                    exception_stack = "".join(
+                        traceback.format_exception(type(e), e, e.__traceback__)
+                    )
+                    raise UnboxResourceError(
+                        context="There is an issue with the specified `explainability_tokenizer`. \n",
+                        message=f"It is failing with the following error: \n{exception_stack}",
+                        mitigation="Make sure your `explainability_tokenizer` receives a list of sentences as input and returns a list of lists of tokens "
+                        + "as output.  Additionally, you may find it useful to debug it on the Jupyter notebook, to ensure it is working correctly before uploading it.",
+                    ) from None
 
         # Transformers resources
         if model_type is ModelType.transformers:


### PR DESCRIPTION
Run validations only if `explainability_tokenizer` is not `None`