### PR TITLE
UNB-2838 - Make project descriptions nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Make project `description` optional.
+
 ## [0.3.0]
 
 ### Added

--- a/unboxapi/schemas.py
+++ b/unboxapi/schemas.py
@@ -16,6 +16,7 @@ class ProjectSchema(Schema):
             min=1,
             max=140,
         ),
+        allow_none=True,
     )
 
 


### PR DESCRIPTION
## Summary

Accepts the project `description` as `null` (`None`). 

There is a corresponding [PR for the backend](https://github.com/unboxai/unbox/pull/391) which updates the project's schema as well.

## Testing

Used all project creation / loading methods with and without descriptions for the Churn notebook. Just reiterating: needs the corresponding backend PR to be merged for it to work.