### PR TITLE
Completes UNB-2755 - Update protobuf requirement on the Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added 
+
+* Added `protobuf<3.20` to requirements to fix compatibility issue with Tensorflow.
+
 ### Changed
 
 * Migrated package name from [openlayer](https://pypi.org/project/openlayer/) to [openlayer](https://pypi.org/project/openlayer/) due to a company name change.

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     requests
     tqdm
     marshmallow
-    protobuf==3.20.0
+    protobuf<3.20
 python_requires = >=3.7
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
## Summary

Defined `protobuf<3.20` as a requirement, to be compatible with the latest version of Tensorflow. 

## Testing

[See Linear](https://linear.app/openlayer/issue/UNB-2755/update-protobuf-requirement-on-the-python-api) for full details.