### PR TITLE
Fix UNB-2945 - Unicode error related to the temporary directory path …

### DIFF
--- a/openlayer/models.py
+++ b/openlayer/models.py
@@ -125,11 +125,11 @@ def _env_dependencies(
         f.write("\n")
         [f.write(f"{dep}\n") for dep in deps]
 
-    env_wrapper_str += f"@env(requirements_txt_file='{openlayer_req_file}'"
+    env_wrapper_str += f"@env(requirements_txt_file=r'{openlayer_req_file}'"
 
     # Add a user defined setup script to execute on startup
     if setup_script:
-        env_wrapper_str += f", setup_sh='{setup_script}')"
+        env_wrapper_str += f", setup_sh=r'{setup_script}')"
     else:
         env_wrapper_str += ")"
     return env_wrapper_str


### PR DESCRIPTION
…for the Bento

## Summary

The references to directories in the Bento service code were breaking for Windows (check [Linear](https://linear.app/openlayer/issue/UNB-2945/unicode-error-related-to-the-temporary-directory-path-for-the-bento) for details). Edited to make them raw strings.

## Testing

I don't have a Windows machine to test if this fixes it, but I'm pretty confident it does. I tested the churn notebook on my Mac to see if the fix introduced problems and it didn't. The only person with a Windows machine is Matheus. I can try to test it with him, if needed.