### PR TITLE
Cid/dataset column validations

### DIFF
--- a/openlayer/__init__.py
+++ b/openlayer/__init__.py
@@ -954,13 +954,31 @@ class OpenlayerClient(object):
         zero_indexed_set = set(range(len(class_names)))
         if unique_labels != zero_indexed_set:
             raise exceptions.OpenlayerResourceError(
-                context=f"There's an issue with values in the column `{label_column_name}` of the dataset. \n",
-                message=f"The labels in `{label_column_name}` must be zero-indexed integer values. \n",
-                mitigation="Make sure to upload a dataset with zero-indexed integer labels that match "
-                f"the list in `class_names`. For example, the class `{class_names[0]}` should be represented as a 0 in the dataset, "
-                f" the class `{class_names[1]}` should be a 1, and so on.",
+                context=f"There's an issue with values in the column "
+                f"`{label_column_name}` of the dataset. \n",
+                message=f"The labels in `{label_column_name}` must be "
+                "zero-indexed integer values. \n",
+                mitigation="Make sure to upload a dataset with zero-indexed "
+                "integer labels that match the list in `class_names`. "
+                f"For example, the class `{class_names[0]}` should be "
+                "represented as a 0 in the dataset, the class "
+                f"`{class_names[1]}` should be a 1, and so on.",
             ) from None
 
+        # Validating the column dtypes
+        supported_dtypes = {"float32", "float64", "int32", "int64", "object"}
+        error_msg = ""
+        for col in df:
+            dtype = df[col].dtype.name
+            if dtype not in supported_dtypes:
+                error_msg += f"- Column `{col}` is of dtype {dtype}. \n"
+        if error_msg:
+            raise exceptions.OpenlayerResourceError(
+                context="There is an issue with some of the columns dtypes.\n",
+                message=error_msg,
+                mitigation=f"The supported dtypes are {supported_dtypes}. "
+                "Make sure to cast the above columns to a supported dtype.",
+            ) from None
         # ------------------ Resource-schema consistency validations ----------------- #
         # Label column validations
         try:


### PR DESCRIPTION
## Summary

Adds two new validations for datasets:
1. Check if the labels are zero indexed integers;
2. Check if the column dtypes are one of the `supported_dtypes`.

Both validations were already happening in the backend. This PR adds them to the Python API to fail early.

There is a related PR for the backend [here](https://github.com/unboxai/openlayer/pull/446).

## Testing

Locally, introducing problems with the dataset that make the validations fail.

Examples:
1.
<img width="983" alt="Screen Shot 2022-09-28 at 18 55 32" src="https://user-images.githubusercontent.com/18015306/192895845-2544184c-7124-448b-88a5-c2ef1d1aa50c.png">

2.

<img width="995" alt="Screen Shot 2022-09-28 at 18 54 21" src="https://user-images.githubusercontent.com/18015306/192895699-53de4056-169e-4165-8ca6-1a5b7403f743.png">
