### PR TITLE
Completes OPEN-3001 Require Python < 3.9 for the Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * Migrated package name from [openlayer](https://pypi.org/project/openlayer/) to [openlayer](https://pypi.org/project/openlayer/) due to a company name change.
+* Required Python version `>=3.7` and `<3.9`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     tqdm
     marshmallow
     protobuf<3.20
-python_requires = >=3.7
+python_requires = >=3.7, <3.9
 include_package_data = True
 setup_requires =
     setuptools>=59.0


### PR DESCRIPTION
## Summary

Required Python < 3.9 due to protobuf issue.

## Testing

If the user tries to install in an env with Python 3.9, they get:

<img width="601" alt="Screen Shot 2022-10-04 at 18 12 09" src="https://user-images.githubusercontent.com/18015306/193930098-adf430ac-0bfb-4fe1-8592-e5f73fa1d07a.png">
