### PR TITLE
Addresses OPEN-1758: For large uploads (several MB) to S3, the upload progress bar no longer jumps to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Added 
+### Fixed
+* Fix warnings related to not closing requests sessions
+* Loading bar no longer jumps from 0% to 100% for large uploads
+
+### Added 
 
 * Added `protobuf<3.20` to requirements to fix compatibility issue with Tensorflow.
 * Warnings if the dependencies from the `requirement_txt_file` and current environment are inconsistent.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     tqdm
     marshmallow
     protobuf<3.20
+    requests_toolbelt
 python_requires = >=3.7, <3.9
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
# Summary

For uploads to S3, our upload progress indicator was not working as expected - the progress would jump to 100%.

Found this thread on stackoverflow on this topic - https://stackoverflow.com/questions/13909900/progress-of-python-requests-post?answertab=modifieddesc#tab-top

The second most recent answer is the solution I used (though the second most upvoted solution also uses `requests_toolbelt`. The problem appears to be with how the `requests` package does not allow for streaming data from files for post requests (i.e. the full file needs to be in memory before the file is uploaded - https://github.com/urllib3/urllib3/issues/51).

As an aside - I think this is part of why our uploads to GCP work just fine at the moment - [we rely on PUT requests for GCP](https://github.com/openlayer-ai/openlayer-python/blob/main/openlayer/api.py#L221) rather than POST. I am not sure why this was done, but we should change it to POST unless I'm missing something.

Though the bar is still uploads instantly for small models (~20KB), it progresses as expected for files that are several MB.

# Testing

Uploaded pytorch models to production endpoint

https://user-images.githubusercontent.com/16823332/194165192-313341bc-56ac-434e-bf82-552c5cfbcec9.mov





# Resources
https://stackoverflow.com/questions/63370330/show-progress-bar-while-uploading-to-s3-using-presigned-url
https://stackoverflow.com/questions/13909900/progress-of-python-requests-post?answertab=trending#tab-top
https://stackoverflow.com/questions/69701215/how-do-i-upload-a-file-into-an-amazon-s3-signed-url-with-python
https://stackoverflow.com/questions/22567306/how-to-upload-file-with-python-requests
https://stackoverflow.com/questions/12385179/how-to-send-a-multipart-form-data-with-requests-in-python
https://stackoverflow.com/questions/21057942/python-unclosed-resource-is-it-safe-to-delete-the-file
https://stackoverflow.com/questions/44592843/python3-reportlab-image-resourcewarning-unclosed-file-io-bufferedreader-na

