### PR TITLE
Completes OPEN-3366 Refactor dataset validations

### DIFF
--- a/openlayer/datasets.py
+++ b/openlayer/datasets.py
@@ -1,3 +1,15 @@
+from enum import Enum
+
+
+class DatasetType(Enum):
+    """The different dataset types that are supported by Openlayer."""
+
+    #: For validation sets.
+    Validation = "validation"
+    #: For training sets.
+    Training = "training"
+
+
 class Dataset:
     """An object containing information about a dataset on the Openlayer platform."""
 

--- a/openlayer/exceptions.py
+++ b/openlayer/exceptions.py
@@ -20,43 +20,15 @@ class OpenlayerException(Exception):
             super().__init__(f"<Response> {message}")
 
 
-class OpenlayerResourceError(OpenlayerException):
-    def __init__(self, message, context=None, mitigation=None):
-        if not context:
-            context = "There is a problem with the specified file path. \n"
-        if not mitigation:
-            mitigation = (
-                "Make sure that the specified filepath contains the expected resource."
-            )
-        super().__init__(context + message + mitigation)
-
-
 class OpenlayerValidationError(OpenlayerException):
-    def __init__(self, message, context=None, mitigation=None):
-        if not context:
-            context = "There are issues with some of the arguments: \n"
-        if not mitigation:
-            mitigation = (
-                "Make sure to respect the datatypes and constraints specified above."
-            )
-        super().__init__(context + message + mitigation)
-
-
-class OpenlayerDatasetInconsistencyError(OpenlayerException):
-    def __init__(self, message, context=None, mitigation=None):
-        if not context:
-            context = "There are inconsistencies between the dataset and some of the arguments: \n"
-        if not mitigation:
-            mitigation = "Make sure that the value specified in the argument is a column header in the dataframe or csv being uploaded."
-        super().__init__(context + message + mitigation)
+    def __init__(self, message):
+        super().__init__(message)
 
 
 class OpenlayerSubscriptionPlanException(OpenlayerException):
     def __init__(self, message, context=None, mitigation=None):
-        if not context:
-            context = "You have reached your subscription plan's limits. \n"
-        if not mitigation:
-            mitigation = "To upgrade your plan, visit https://openlayer.com"
+        context = context or "You have reached your subscription plan's limits. \n"
+        mitigation = mitigation or "To upgrade your plan, visit https://openlayer.com"
         super().__init__(context + message + mitigation)
 
 

--- a/openlayer/models.py
+++ b/openlayer/models.py
@@ -10,7 +10,7 @@ class ModelType(Enum):
     """
 
     #: For custom built models.
-    custom = "Custom"
+    custom = "custom"
     #: For models built with `fastText <https://fasttext.cc/>`_.
     fasttext = "fasttext"
     #: For models built with `Keras <https://keras.io/>`_.

--- a/openlayer/schemas.py
+++ b/openlayer/schemas.py
@@ -1,5 +1,6 @@
 import marshmallow as ma
 
+from .datasets import DatasetType
 from .models import ModelType
 
 
@@ -55,9 +56,11 @@ class DatasetSchema(ma.Schema):
             max=140,
         ),
     )
-    tag_column_name = ma.fields.List(
-        ma.fields.Str(),
-        allow_none=True,
+    dataset_type = ma.fields.Str(
+        validate=ma.validate.OneOf(
+            [dataset_type.value for dataset_type in DatasetType],
+            error=f"`dataset_type` must be one of the supported frameworks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.DatasetType.html.\n ",
+        ),
     )
     class_names = ma.fields.List(
         ma.fields.Str(),
@@ -73,7 +76,6 @@ class DatasetSchema(ma.Schema):
     sep = ma.fields.Str()
     feature_names = ma.fields.List(
         ma.fields.Str(),
-        allow_none=True,
     )
     text_column_name = ma.fields.Str(
         allow_none=True,

--- a/openlayer/utils.py
+++ b/openlayer/utils.py
@@ -99,18 +99,3 @@ def remove_python_version(dir: str):
         dir (str): the directory to remove the file from.
     """
     os.remove(f"{dir}/python_version")
-
-
-def copy_to_tmp_dir(dir: str) -> str:
-    """Copies the contents of the specified directory (`dir`) to a temporary directory.
-
-    Args:
-        dir (str): the directory to copy the contents from.
-
-    Returns:
-        str: the path to the temporary directory.
-    """
-    tmp_dir = tempfile.mkdtemp()
-    distutils.dir_util.copy_tree(dir, tmp_dir)
-
-    return tmp_dir

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,13 +24,11 @@ project_urls =
 [options]
 packages = openlayer
 install_requires =
-    bentoml==0.13.1
     jupyter
     pandas
     requests
     tqdm
     marshmallow
-    protobuf<3.20
     requests_toolbelt
 python_requires = >=3.7, <3.9
 include_package_data = True


### PR DESCRIPTION
Refactors the dataset validations and introduces dataset types (for training and validation sets).

## Summary
- Factored out the validations done for the datasets to the `DatasetValidator` class, analogous to the `ModelValidator` introduced in a previous PR.
- Additionally, introduced the `dataset_type` argument, which can be either `DatasetType.Training` or `DatasetType.Validation`.


## Additional comments
- I'll finish updating the docstrings once we have the new commit-style in place.
- I'm not yet fully satisfied with how we pass the args to the `add_dataset`. I introduced the possibility of passing it via a `dataset_config.yaml` file (analogous to the `model_config.yaml` for models), but it still feels a bit awkward. I'll continue thinking about it.