### PR TITLE
Completes OPEN-3213 Reorganize Python API into commit-style uploads

### DIFF
--- a/openlayer/projects.py
+++ b/openlayer/projects.py
@@ -1,8 +1,5 @@
 from openlayer import tasks
 
-from .datasets import Dataset
-from .models import Model
-
 
 class Project:
     """An object containing information about a project on the Openlayer platform."""
@@ -41,7 +38,7 @@ class Project:
         self,
         *args,
         **kwargs,
-    ) -> Model:
+    ):
         return self.client.add_model(
             *args, project_id=self.id, task_type=tasks.TaskType(self.taskType), **kwargs
         )
@@ -50,12 +47,24 @@ class Project:
         self,
         *args,
         **kwargs,
-    ) -> Dataset:
+    ):
         return self.client.add_dataset(
             *args, project_id=self.id, task_type=tasks.TaskType(self.taskType), **kwargs
         )
 
-    def add_dataframe(self, *args, **kwargs) -> Dataset:
+    def add_dataframe(self, *args, **kwargs):
         return self.client.add_dataframe(
             *args, project_id=self.id, task_type=tasks.TaskType(self.taskType), **kwargs
         )
+
+    def commit(self, *args, **kwargs):
+        return self.client.commit(*args, project_id=self.id, **kwargs)
+
+    def push(self, *args, **kwargs):
+        return self.client.push(*args, project_id=self.id, **kwargs)
+
+    def status(self, *args, **kwargs):
+        return self.client.status(*args, project_id=self.id, **kwargs)
+
+    def restore(self, *args, **kwargs):
+        return self.client.restore(*args, project_id=self.id, **kwargs)

--- a/openlayer/schemas.py
+++ b/openlayer/schemas.py
@@ -2,49 +2,16 @@ import marshmallow as ma
 
 from .datasets import DatasetType
 from .models import ModelType
+from .tasks import TaskType
 
 
-class ProjectSchema(ma.Schema):
-    name = ma.fields.Str(
+class CommitSchema(ma.Schema):
+    commit_message = ma.fields.Str(
         required=True,
-        validate=ma.validate.Length(
-            min=1,
-            max=64,
-        ),
-    )
-    description = ma.fields.Str(
         validate=ma.validate.Length(
             min=1,
             max=140,
         ),
-        allow_none=True,
-    )
-
-
-class ModelSchema(ma.Schema):
-    name = ma.fields.Str(
-        required=True,
-        validate=ma.validate.Length(
-            min=1,
-            max=64,
-        ),
-    )
-    model_type = ma.fields.Str(
-        validate=ma.validate.OneOf(
-            [model_framework.value for model_framework in ModelType],
-            error=f"`model_type` must be one of the supported frameworks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.ModelType.html.\n ",
-        ),
-        allow_none=True,
-    )
-    class_names = ma.fields.List(
-        ma.fields.Str(),
-    )
-    feature_names = ma.fields.List(
-        ma.fields.Str(),
-        allow_none=True,
-    )
-    categorical_feature_names = ma.fields.List(
-        ma.fields.Str(),
     )
 
 
@@ -91,3 +58,52 @@ class DatasetSchema(ma.Schema):
             raise ma.ValidationError(
                 f"`label_column_name` `{data['label_column_name']}` must not be in `feature_names`."
             )
+
+
+class ModelSchema(ma.Schema):
+    name = ma.fields.Str(
+        required=True,
+        validate=ma.validate.Length(
+            min=1,
+            max=64,
+        ),
+    )
+    model_type = ma.fields.Str(
+        validate=ma.validate.OneOf(
+            [model_framework.value for model_framework in ModelType],
+            error=f"`model_type` must be one of the supported frameworks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.ModelType.html.\n ",
+        ),
+        allow_none=True,
+    )
+    class_names = ma.fields.List(
+        ma.fields.Str(),
+    )
+    feature_names = ma.fields.List(
+        ma.fields.Str(),
+        allow_none=True,
+    )
+    categorical_feature_names = ma.fields.List(
+        ma.fields.Str(),
+    )
+
+
+class ProjectSchema(ma.Schema):
+    name = ma.fields.Str(
+        required=True,
+        validate=ma.validate.Length(
+            min=1,
+            max=64,
+        ),
+    )
+    description = ma.fields.Str(
+        validate=ma.validate.Length(
+            min=1,
+            max=140,
+        ),
+    )
+    task_type = ma.fields.Str(
+        alidate=ma.validate.OneOf(
+            [task_type.value for task_type in TaskType],
+            error=f"`task_type` must be one of the supported tasks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.TaskType.html.\n ",
+        ),
+    )

--- a/openlayer/utils.py
+++ b/openlayer/utils.py
@@ -1,8 +1,5 @@
-import distutils
 import os
-import shutil
 import sys
-import tempfile
 import warnings
 
 
@@ -25,50 +22,6 @@ class HidePrints:
         sys.stdout = self._original_stdout
         sys._jupyter_stdout = sys.stdout
         warnings.filterwarnings("default")
-
-
-class TempDirectory(object):
-    """Helper class that creates and cleans up a temporary directory.
-
-    >>> with TempDirectory() as tempdir:
-    >>>     print(os.path.isdir(tempdir))
-    """
-
-    def __init__(
-        self,
-        cleanup=True,
-        prefix="temp",
-    ):
-
-        self._cleanup = cleanup
-        self._prefix = prefix
-        self.path = None
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} {self.path}>"
-
-    def __enter__(self):
-        self.create()
-        return self.path
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._cleanup:
-            self.cleanup()
-
-    def create(self):
-        if self.path is not None:
-            return self.path
-
-        tempdir = tempfile.mkdtemp(prefix=f"openlayer-{self._prefix}-")
-        self.path = os.path.realpath(tempdir)
-
-    def cleanup(self, ignore_errors=False):
-        """
-        Remove the temporary directory created
-        """
-        if self.path is not None and os.path.exists(self.path):
-            shutil.rmtree(self.path, ignore_errors=ignore_errors)
-        self.path = None
 
 
 # ----------------------------- Helper functions ----------------------------- #


### PR DESCRIPTION
Introduces the commit-style to the Python API.

## Summary
- Now, the `add` methods, instead of uploading the resources directly to the platform, stages them.
- After staging, the user is supposed to `commit` (providing a message) and then `push`.
- Two convenience methods are also provided, namely:
    1. `status`: shows the resources staged and the commit message (if any) -- similar to `git status`;
    2. `restore`: removes a resource from the staging area -- similar to `git restore`.

## Behind the scenes
Behind the scenes, when the user instantiates the client, we check whether the directory `~/.openlayer` exists. If it doesn't, we create it.

Then, when the user creates or loads a project, we create (or leave as is) a staging directory for the specific project. For example, if the user never interacted with the project with id 55 locally, we create the directories: 
```
~/.openlayer
    /55
       /staging
```
When a user adds a resource, we stage it by copying the relevant artifacts to the staging area. The relevant artifacts are the model package, for models, and the csv + a yaml with the dataset configs, for datasets. For example, if the user adds a training set, the staging area looks like:
```
~/.openlayer
    /55
       /staging
           /training
               {uuid}.csv
               dataset_config.yaml
```
When a user adds the commit message, we write a `commit.yaml` file to the staging area. The `commit.yaml` contains the commit message and the date time of creation (in a readable format).
```
~/.openlayer
    /55
       /staging
           commit.yaml
           /training
               {uuid}.csv
               dataset_config.yaml
```

On `push`, the staging area gets tarred (for upload) and then cleaned up.

There are a lot of edge cases handled. The easiest ways to understand them are to interact with the API or to check the (partially complete) Figma file with the flows (sent an invite to @whoseoyster and @Parthib). In summary, if the user calls `add` more than once, we ask them if they'd like to overwrite the currently staged file. The same on multiple `commit` calls. On the second `push` call, the user will receive a message that there is nothing to be pushed.