### PR TITLE
Completes OPEN-3479 Add support for shell models on the Python API

### DIFF
--- a/openlayer/schemas.py
+++ b/openlayer/schemas.py
@@ -1,3 +1,5 @@
+"""Schemas for the objects that shall be created on the Openlayer platform.
+"""
 import marshmallow as ma
 
 from .datasets import DatasetType
@@ -6,7 +8,9 @@ from .tasks import TaskType
 
 
 class CommitSchema(ma.Schema):
-    commit_message = ma.fields.Str(
+    """Schema for commits."""
+
+    commitMessage = ma.fields.Str(
         required=True,
         validate=ma.validate.Length(
             min=1,
@@ -16,54 +20,60 @@ class CommitSchema(ma.Schema):
 
 
 class DatasetSchema(ma.Schema):
-    file_path = ma.fields.Str()
-    commit_message = ma.fields.Str(
-        validate=ma.validate.Length(
-            min=1,
-            max=140,
-        ),
+    """Schema for datasets."""
+
+    categoricalFeatureNames = ma.fields.List(
+        ma.fields.Str(), allow_none=True, load_default=[]
     )
-    dataset_type = ma.fields.Str(
+    classNames = ma.fields.List(ma.fields.Str(), required=True)
+    columnNames = ma.fields.List(
+        ma.fields.Str(),
+        required=True,
+    )
+    label = ma.fields.Str(
         validate=ma.validate.OneOf(
             [dataset_type.value for dataset_type in DatasetType],
-            error=f"`dataset_type` must be one of the supported frameworks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.DatasetType.html.\n ",
+            error="`label` must be one of the supported frameworks."
+            + "Check out our API reference for a full list"
+            + " https://reference.openlayer.com/reference/api/openlayer.DatasetType.html.\n ",
         ),
+        required=True,
     )
-    class_names = ma.fields.List(
+    featureNames = ma.fields.List(
         ma.fields.Str(),
+        load_default=[],
     )
-    label_column_name = ma.fields.Str()
+    labelColumnName = ma.fields.Str(required=True)
     language = ma.fields.Str(
-        default="en",
+        load_default="en",
         validate=ma.validate.Regexp(
             r"^[a-z]{2}(-[A-Z]{2})?$",
             error="`language` of the dataset is not in the ISO 639-1 (alpha-2 code) format.",
         ),
     )
-    sep = ma.fields.Str()
-    predictions_column_name = ma.fields.Str(
+    metadata = ma.fields.Dict(allow_none=True, load_default={})
+    predictionsColumnName = ma.fields.Str(allow_none=True, load_default=None)
+    sep = ma.fields.Str(load_default=",")
+    textColumnName = ma.fields.Str(
         allow_none=True,
-    )
-    feature_names = ma.fields.List(
-        ma.fields.Str(),
-    )
-    text_column_name = ma.fields.Str(
-        allow_none=True,
-    )
-    categorical_feature_names = ma.fields.List(
-        ma.fields.Str(),
     )
 
     @ma.validates_schema
     def validates_label_column_not_in_feature_names(self, data, **kwargs):
         """Validates whether the label column name is not on the feature names list"""
-        if data["label_column_name"] in data["feature_names"]:
+        if data["labelColumnName"] in data["featureNames"]:
             raise ma.ValidationError(
-                f"`label_column_name` `{data['label_column_name']}` must not be in `feature_names`."
+                f"`labelColumnName` `{data['labelColumnName']}` must not be in `featureNames`."
             )
 
 
 class ModelSchema(ma.Schema):
+    """Schema for models with artifacts (i.e., model_package)."""
+
+    categoricalFeatureNames = ma.fields.List(ma.fields.Str(), load_default=[])
+    classNames = ma.fields.List(
+        ma.fields.Str(),
+    )
     name = ma.fields.Str(
         required=True,
         validate=ma.validate.Length(
@@ -71,42 +81,68 @@ class ModelSchema(ma.Schema):
             max=64,
         ),
     )
-    model_type = ma.fields.Str(
+    featureNames = ma.fields.List(ma.fields.Str(), allow_none=True, load_default=[])
+    metadata = ma.fields.Dict(
+        allow_none=True,
+        load_default={},
+    )
+    architectureType = ma.fields.Str(
         validate=ma.validate.OneOf(
             [model_framework.value for model_framework in ModelType],
-            error=f"`model_type` must be one of the supported frameworks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.ModelType.html.\n ",
+            error="`architectureType` must be one of the supported frameworks."
+            + " Check out our API reference for a full list"
+            + " https://reference.openlayer.com/reference/api/openlayer.ModelType.html.\n ",
         ),
-        allow_none=True,
-    )
-    class_names = ma.fields.List(
-        ma.fields.Str(),
-    )
-    feature_names = ma.fields.List(
-        ma.fields.Str(),
-        allow_none=True,
-    )
-    categorical_feature_names = ma.fields.List(
-        ma.fields.Str(),
+        required=True,
     )
 
 
 class ProjectSchema(ma.Schema):
-    name = ma.fields.Str(
-        required=True,
-        validate=ma.validate.Length(
-            min=1,
-            max=64,
-        ),
-    )
+    """Schema for projects."""
+
     description = ma.fields.Str(
         validate=ma.validate.Length(
             min=1,
             max=140,
         ),
     )
+    name = ma.fields.Str(
+        required=True,
+        validate=ma.validate.Length(
+            min=1,
+            max=64,
+        ),
+    )
     task_type = ma.fields.Str(
         alidate=ma.validate.OneOf(
             [task_type.value for task_type in TaskType],
-            error=f"`task_type` must be one of the supported tasks. Check out our API reference for a full list https://reference.openlayer.com/reference/api/openlayer.TaskType.html.\n ",
+            error="`task_type` must be one of the supported tasks."
+            + " Check out our API reference for a full list"
+            + " https://reference.openlayer.com/reference/api/openlayer.TaskType.html.\n ",
         ),
+    )
+
+
+class ShellModelSchema(ma.Schema):
+    """Schema for models without artifacts (i.e., shell model)."""
+
+    name = ma.fields.Str(
+        required=True,
+        validate=ma.validate.Length(
+            min=1,
+            max=64,
+        ),
+    )
+    metadata = ma.fields.Dict(
+        allow_none=True,
+        load_default={},
+    )
+    architectureType = ma.fields.Str(
+        validate=ma.validate.OneOf(
+            [model_framework.value for model_framework in ModelType],
+            error="`architectureType` must be one of the supported frameworks. "
+            + "Check out our API reference for a full list"
+            + " https://reference.openlayer.com/reference/api/openlayer.ModelType.html.\n ",
+        ),
+        required=True,
     )

--- a/openlayer/utils.py
+++ b/openlayer/utils.py
@@ -2,6 +2,8 @@ import os
 import sys
 import warnings
 
+import yaml
+
 
 # -------------------------- Helper context managers ------------------------- #
 class HidePrints:
@@ -25,18 +27,18 @@ class HidePrints:
 
 
 # ----------------------------- Helper functions ----------------------------- #
-def write_python_version(dir: str):
+def write_python_version(directory: str):
     """Writes the python version to the file `python_version` in the specified
-    directory (`dir`).
+    directory (`directory`).
 
     This is used to register the Python version of the user's environment in the
     when they are uploading a model package.
 
     Args:
-        dir (str): the directory to write the file to.
+        directory (str): the directory to write the file to.
     """
-    with open(f"{dir}/python_version", "w") as f:
-        f.write(
+    with open(f"{directory}/python_version", "w") as file:
+        file.write(
             str(sys.version_info.major)
             + "."
             + str(sys.version_info.minor)
@@ -45,10 +47,35 @@ def write_python_version(dir: str):
         )
 
 
-def remove_python_version(dir: str):
-    """Removes the file `python_version` from the specified directory (`dir`).
+def remove_python_version(directory: str):
+    """Removes the file `python_version` from the specified directory
+    (`directory`).
 
     Args:
-        dir (str): the directory to remove the file from.
+        directory (str): the directory to remove the file from.
     """
-    os.remove(f"{dir}/python_version")
+    os.remove(f"{directory}/python_version")
+
+
+def read_yaml(filename: str) -> dict:
+    """Reads a YAML file and returns it as a dictionary.
+
+    Args:
+        filename (str): the path to the YAML file.
+
+    Returns:
+        dict: the dictionary representation of the YAML file.
+    """
+    with open(filename, "r") as stream:
+        return yaml.safe_load(stream)
+
+
+def write_yaml(dictionary: dict, filename: str):
+    """Writes the dictionary to a YAML file in the specified directory (`dir`).
+
+    Args:
+        dictionary (dict): the dictionary to write to a YAML file.
+        dir (str): the directory to write the file to.
+    """
+    with open(filename, "w") as stream:
+        yaml.dump(dictionary, stream)


### PR DESCRIPTION
## Summary
- Adds support for shell models (i.e., models with only a `model_config.yaml` without artifacts).
- Refactored args so that for all `add` methods, a YAML config file is passed.
- Config args follow a camelCase format. Naming is now consistent with the backend.
- Updated docstrings.