### PR TITLE
Completes OPEN-3490 Create a method inside the CommitBundleValidator …

### DIFF
--- a/openlayer/__init__.py
+++ b/openlayer/__init__.py
@@ -974,7 +974,7 @@ class OpenlayerClient(object):
 
         # Validate bundle resources
         commit_bundle_validator = validators.CommitBundleValidator(
-            commit_bundle_path=project_dir
+            bundle_path=project_dir
         )
         failed_validations = commit_bundle_validator.validate()
 

--- a/openlayer/utils.py
+++ b/openlayer/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 import warnings
 
 import yaml
@@ -79,3 +80,12 @@ def write_yaml(dictionary: dict, filename: str):
     """
     with open(filename, "w") as stream:
         yaml.dump(dictionary, stream)
+
+
+def get_exception_stacktrace(err: Exception):
+    """Returns the stacktrace of the most recent exception.
+
+    Returns:
+        str: the stacktrace of the most recent exception.
+    """
+    return "".join(traceback.format_exception(type(err), err, err.__traceback__))


### PR DESCRIPTION
…that validates all resources individually

- For a commit bundle, includes the individual resource validation. This is done mostly to simplify the commit bundle validation on the backend (introduced by [this PR](https://github.com/openlayer-ai/openlayer/pull/626))
- There are minor issues with the way these additional validations are being done. The main one being that the datasets and models are essentially validated twice: once on the `add` and once on the `push`. I can allow for something like `skip_validations` in the future. I'll also change the references to `"training"`, "`validation`", and "`model`" to use an enum, like we do for the backend. 