### PR TITLE
Completes OPEN-3563 Add model property indicating if baseline / shell…

### DIFF
--- a/openlayer/schemas.py
+++ b/openlayer/schemas.py
@@ -23,6 +23,7 @@ class BaselineModelSchema(ma.Schema):
     """Schema for baseline models."""
 
     metadata = ma.fields.Dict(allow_none=True, load_default={})
+    modelType = ma.fields.Str()
 
 
 class CommitSchema(ma.Schema):
@@ -119,6 +120,7 @@ class ModelSchema(ma.Schema):
         allow_none=True,
         load_default={},
     )
+    modelType = ma.fields.Str()
     architectureType = ma.fields.Str(
         validate=ma.validate.OneOf(
             [model_framework.value for model_framework in ModelType],


### PR DESCRIPTION
… / non-shell and Closes OPEN-3616 Replace 'baseline-model' resource name in favor of common 'model' resource

## Summary

- Gets rid of the `baseline-model` resource in the staging area. Instead, uses the common `model` resource name.
- Adds the `modelType` to the `ModelSchema` and `BaselineModelSchema`. This property indicates whether the model is a `shell`, `baseline` or `full` model. This is now expected by the backend (from [this PR](https://github.com/openlayer-ai/openlayer/pull/670)).
- Other than that, just updates the validation logic to work with the new resource names.