### PR TITLE
Closes OPEN-3861 Improve stack trace handling when commit bundle is n…

### DIFF
--- a/openlayer/validators.py
+++ b/openlayer/validators.py
@@ -161,7 +161,11 @@ class CommitBundleValidator:
             "----------------------------------------------------------------------------\n"
         )
         self._validate_bundle_state()
-        self._validate_bundle_resources()
+
+        # Validate individual resources only if the bundle is in a valid state
+        # TODO: improve the logic that determines whether to validate individual resources
+        if not self.failed_validations:
+            self._validate_bundle_resources()
 
         if not self.failed_validations:
             logger.info(
@@ -230,7 +234,7 @@ class CommitBundleValidator:
                 bundle_state_failed_validations.append(
                     "To push a model to the platform, you must provide "
                     "training and a validation sets with predictions in the column "
-                    "`predictions_column_name`."
+                    "specified by `predictionsColumnName`."
                 )
             if model_type == "baseline":
                 if (
@@ -248,7 +252,7 @@ class CommitBundleValidator:
                     bundle_state_failed_validations.append(
                         "To push a baseline model to the platform, you must provide "
                         "training and validation sets without predictions in the column "
-                        "`predictions_column_name`."
+                        "specified by `predictionsColumnName`."
                     )
         else:
             if (


### PR DESCRIPTION
…ot in a valid state

- Validates the individual resources inside the commit bundle only if the bundle is in a valid state. 
- This can be suboptimal, because there are issues that we could report back to users even if the bundle is in an invalid state. On the other hand, this is safest option and avoids issues (such as trying to load data to validate the model when there is no dataset in the bundle.)
- The flow can be improved. I'll think of something better than checking `self.failed_validations` multiple times in the future.