### PR TITLE
OPEN-3938: New VERIFY_REQUESTS parameter gives control over custom SSL certificate path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Added `protobuf<3.20` to requirements to fix compatibility issue with Tensorflow.
 * Warnings if the dependencies from the `requirement_txt_file` and current environment are inconsistent.
+* Paths to custom SSL certificates can now be modified by altering `openlayer.api.VERIFY_REQUESTS`. The value can either be True (default), False, or a path to a certificate.
 
 ### Changed
 

--- a/openlayer/api.py
+++ b/openlayer/api.py
@@ -31,6 +31,9 @@ class StorageType(Enum):
 
 STORAGE = StorageType.AWS
 OPENLAYER_ENDPOINT = "https://api.openlayer.com/v1"
+# Controls the `verify` parameter on requests in case a custom
+# certificate is needed or needs to be disabled altogether
+VERIFY_REQUESTS = True
 
 
 class Api:
@@ -201,7 +204,7 @@ class Api:
                     e, lambda monitor: t.update(min(t.total, monitor.bytes_read) - t.n)
                 )
                 headers = {"Content-Type": m.content_type}
-                res = requests.post(presigned_json["url"], data=m, headers=headers)
+                res = requests.post(presigned_json["url"], data=m, headers=headers, verify=VERIFY_REQUESTS)
 
         if res.ok:
             body["storageUri"] = presigned_json["storageUri"]
@@ -229,6 +232,7 @@ class Api:
                     presigned_json["url"],
                     data=wrapped_file,
                     headers={"Content-Type": "application/x-gzip"},
+                    verify=VERIFY_REQUESTS
                 )
         if res.ok:
             body["storageUri"] = presigned_json["storageUri"]
@@ -259,6 +263,7 @@ class Api:
                         "Content-Type": "application/x-gzip",
                         "x-ms-blob-type": "BlockBlob",
                     },
+                    verify=VERIFY_REQUESTS
                 )
         if res.ok:
             body["storageUri"] = presigned_json["storageUri"]

--- a/openlayer/version.py
+++ b/openlayer/version.py
@@ -1,3 +1,3 @@
 # Define the SDK version here so that the interal package can have access to this value.
 # See https://stackoverflow.com/questions/2058802
-__version__ = "0.0.0a11"
+__version__ = "0.0.0a12"


### PR DESCRIPTION
# Summary

The processor worker uses the Openlayer client to upload to S3. Ebay has a custom version of S3 that has its own self-signed certificates. Since the CA cert authority for the certificate is internal to eBay, our client does not recognize it and the requests fail:

```
  File "/home/openlayer/./processors/processor_base.py", line 137, in write_artifact_to_storage
    api.upload(
  File "/usr/local/lib/python3.8/site-packages/openlayer/api.py", line 172, in upload
    return upload(
  File "/usr/local/lib/python3.8/site-packages/openlayer/api.py", line 204, in upload_blob_s3
    res = requests.post(presigned_json["url"], data=m, headers=headers)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 115, in post
    return request("post", url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/adapters.py", line 563, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='unbox.nuobject.io', port=443): Max retries exceeded with url: /openlayer-models (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1131)')))
```

The only way to get around this is to either turn off SSL validation or give the requests library a path to a cert that the requests library should trust. Both of these can be supplied via the `VERIFY_REQUESTS` field in API on the client

# Testing
Installed the new client and ran jupyter notebook. Added the statement `print(openlayer.api.VERIFY_REQUESTS)` and log lines printed `True`