### PR TITLE
Closes OPEN-4056 Zero-indexed labels validation doesn't allow dataset…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* Modified the zero-index integer checks for `predictionsColumnName` and `labelColumnName` to support dataset uploads with only a sample of the classes.
 * Renamed `predictionsColumnName` argument from the datasets' configuration YAML to `predictionScoresColumnName`. 
 * Migrated package name from [openlayer](https://pypi.org/project/openlayer/) to [openlayer](https://pypi.org/project/openlayer/) due to a company name change.
 * Required Python version `>=3.7` and `<3.9`.


### PR DESCRIPTION
…s with only a sample of the labels to be uploaded and Closes OPEN-4044 Add a data type validation prior to the other prediction checks

- Previously, the zero-index check expected all classes to be represented in the dataset's column `labelColumnNames` (e.g. `set(unique_labels) == set(range(num_classes))`.
- This validation failed if not all classes were present in the dataset, even if they were zero-indexed ints. 
- With the new validation, we look for the max class in the column. Then check if `max_class > len(class_names) - 1`. If so, the validation fails (there are more classes in the dataset than in the `class_names` list.
- This is a blocker for the Take pilot.