### PR TITLE
Completes OPEN-4126 Append timestamp / date information to conda env …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* Renamed conda environment created by the model runner from `new-openlayer` to `model-runner-env-%m-%d-%H-%M-%S-%f`. 
 * Modified the zero-index integer checks for `predictionsColumnName` and `labelColumnName` to support dataset uploads with only a sample of the classes.
 * Renamed `predictionsColumnName` argument from the datasets' configuration YAML to `predictionScoresColumnName`. 
 * Migrated package name from [openlayer](https://pypi.org/project/openlayer/) to [openlayer](https://pypi.org/project/openlayer/) due to a company name change.

--- a/openlayer/models.py
+++ b/openlayer/models.py
@@ -1,4 +1,5 @@
 import ast
+import datetime
 import logging
 import os
 import shutil
@@ -318,7 +319,7 @@ class ModelRunner:
 
         # TODO: change env name to the model id
         self._conda_environment = CondaEnvironment(
-            env_name="new-openlayer",
+            env_name=f"model-runner-env-{datetime.datetime.now().strftime('%m-%d-%H-%M-%S-%f')}",
             requirements_file_path=f"{model_package}/requirements.txt",
             python_version_file_path=f"{model_package}/python_version",
             logger=self.logger,


### PR DESCRIPTION
…created by the model runner

- Adds time info to the conda env name created by the model runner.
- Avoids race condition when two processor workers are running at the same time and need to create envs.
- Assumes two conda envs are not going to be created at the same millisecond.