### PR TITLE
Completes OPEN-4127 Create export function to the Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* Added the project's `export` method, which exports the resources in the project's staging area to a specified location.
 * Added `llm` as a supported `architectureType` for models.
 * Added `protobuf<3.20` to requirements to fix compatibility issue with Tensorflow.
 * Warnings if the dependencies from the `requirement_txt_file` and current environment are inconsistent.

--- a/docs/source/reference/upload.rst
+++ b/docs/source/reference/upload.rst
@@ -44,6 +44,7 @@ Version control flow
    OpenlayerClient.push
    OpenlayerClient.status
    OpenlayerClient.restore
+   OpenlayerClient.export
 
 Task types
 ----------

--- a/openlayer/projects.py
+++ b/openlayer/projects.py
@@ -75,6 +75,10 @@ class Project:
         """Pushes the commited resources to the platform."""
         return self.client.push(*args, project_id=self.id, **kwargs)
 
+    def export(self, *args, **kwargs):
+        """Exports the commited resources to a specified location."""
+        return self.client.export(*args, project_id=self.id, **kwargs)
+
     def status(self, *args, **kwargs):
         """Shows the state of the staging area."""
         return self.client.status(*args, project_id=self.id, **kwargs)


### PR DESCRIPTION
- Introduces the `export` method to the Python API.
- The method is very similar to `push`, but instead of uploading a tar file at the end, the tar file is saved to the directory specified as `destination_dir`.
- By doing so, users can potentially drag and drop the staging area to the platform using the platform's UI (future work), which can make the upload process faster.