### PR TITLE
Completes OPEN-4488 Update transformers version for notebook example

### DIFF
--- a/examples/text-classification/transformers/requirements.txt
+++ b/examples/text-classification/transformers/requirements.txt
@@ -1,8 +1,10 @@
-scipy==1.7.3
-torch==1.13.1
-transformers==4.20.1
-wheel==0.38.1
-setuptools==65.5.1
-pandas==1.1.4
+accelerate==0.20.1
 datasets==2.11.0
 evaluate==0.4.0
+pandas==1.1.4
+scikit-learn==1.2.2
+scipy==1.7.3
+setuptools==65.5.1
+torch==1.13.1
+transformers==4.30
+wheel==0.38.1


### PR DESCRIPTION
- Updated `transformers` version to 4.30 due to vulnerability with <4.30.
- Updated some other requirements from this sample notebook to ensure everything works with the new `transformers` version.