### PR TITLE
Closes OPEN-4602 Fix issue with pandas Series for text classification…

### DIFF
--- a/openlayer/validators/commit_validators.py
+++ b/openlayer/validators/commit_validators.py
@@ -391,7 +391,7 @@ class TextCommitBundleValidator(BaseCommitBundleValidator):
         )
         if validation_dataset_df is not None:
             sample_data = validation_dataset_df[
-                self.validation_dataset_config["textColumnName"]
+                [self.validation_dataset_config["textColumnName"]]
             ].head()
 
         return sample_data


### PR DESCRIPTION
… commit bundle validation

## Summary

- Tiny edit to ensure that the sample data used to validate text classification commit bundles is a pandas df and not a pandas series.
- The issue only arose on pushes, where we get a sample of the user's validation set and try to run it through the model.