### PR TITLE
Update scikit-learn, pandas, numpy, and xgboost versions for notebook…

### DIFF
--- a/examples/tabular-classification/documentation-tutorial/requirements.txt
+++ b/examples/tabular-classification/documentation-tutorial/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/tabular-classification/sklearn/churn-classifier/requirements.txt
+++ b/examples/tabular-classification/sklearn/churn-classifier/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/tabular-classification/sklearn/fetal-health/requirements.txt
+++ b/examples/tabular-classification/sklearn/fetal-health/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/tabular-classification/sklearn/fraud-detection/requirements.txt
+++ b/examples/tabular-classification/sklearn/fraud-detection/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/tabular-classification/sklearn/iris-classifier/requirements.txt
+++ b/examples/tabular-classification/sklearn/iris-classifier/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/tabular-classification/xgboost/requirements.txt
+++ b/examples/tabular-classification/xgboost/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn==1.0.2
-numpy>=1.20
-pandas==1.1.4
-xgboost==1.6.1
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2
+xgboost==1.7

--- a/examples/tabular-regression/sklearn/diabetes-prediction/requirements.txt
+++ b/examples/tabular-regression/sklearn/diabetes-prediction/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.24
+numpy>=1.22
 pandas==1.5.3
 scikit-learn==1.2.2

--- a/examples/text-classification/documentation-tutorial/requirements.txt
+++ b/examples/text-classification/documentation-tutorial/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/text-classification/fasttext/requirements.txt
+++ b/examples/text-classification/fasttext/requirements.txt
@@ -1,3 +1,4 @@
 fasttext==0.9.2
-numpy>=1.20
-pandas==1.1.4
+numpy>=1.22
+pandas==1.5.3
+

--- a/examples/text-classification/sklearn/banking/requirements.txt
+++ b/examples/text-classification/sklearn/banking/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2

--- a/examples/text-classification/sklearn/sentiment-analysis/requirements.txt
+++ b/examples/text-classification/sklearn/sentiment-analysis/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
-pandas==1.1.4
-scikit-learn==0.24.2
+numpy>=1.22
+pandas==1.5.3
+scikit-learn==1.2.2


### PR DESCRIPTION
… examples

## Summary

- Updated requirements.txt files for the notebook examples that used `numpy`, `pandas`, `scikit-learn`, and `xgboost`.
- New versions are installed much faster for Python >= 3.9, which is what Google Colab is currently using.
