### PR TITLE
OPEN-5105: Changes to support monitoring data ingestion without InferencePipelineData objects

### DIFF
--- a/openlayer/__init__.py
+++ b/openlayer/__init__.py
@@ -26,12 +26,12 @@ import shutil
 import tarfile
 import tempfile
 import time
+import urllib.parse
 import uuid
 import warnings
 from typing import Dict, Optional, Tuple
 
 import pandas as pd
-import urllib.parse
 import yaml
 
 from . import api, constants, exceptions, utils
@@ -922,7 +922,7 @@ class OpenlayerClient(object):
                     {"task_type": task_type.value, **reference_dataset_config}
                 )
 
-            with tempfile.TemporaryDirectory() as tmp_dir:  
+            with tempfile.TemporaryDirectory() as tmp_dir:
                 # Copy relevant files to tmp dir if reference dataset is provided
                 if reference_dataset_config_file_path is not None:
                     utils.write_yaml(
@@ -1135,9 +1135,7 @@ class OpenlayerClient(object):
             with tarfile.open(tar_file_path, mode="w:gz") as tar:
                 tar.add(tmp_dir, arcname=os.path.basename("batch_data"))
 
-            payload = {
-                "performGroundTruthMerge": False,
-            }
+            payload = {"performGroundTruthMerge": False}
 
             presigned_url_query_params_dict = {
                 "earliestTimestamp": int(earliest_timestamp),
@@ -1157,8 +1155,10 @@ class OpenlayerClient(object):
                 body=payload,
                 storage_uri_key="storageUri",
                 method="POST",
-                presigned_url_endpoint=f"inference-pipelines/{inference_pipeline_id}/presigned-url",
-                presigned_url_query_params=presigned_url_query_params
+                presigned_url_endpoint=(
+                    f"inference-pipelines/{inference_pipeline_id}/presigned-url"
+                ),
+                presigned_url_query_params=presigned_url_query_params,
             )
 
         print("Batch of data published!")
@@ -1232,6 +1232,6 @@ class OpenlayerClient(object):
                 storage_uri_key="storageUri",
                 method="POST",
                 presigned_url_endpoint=f"inference-pipelines/{inference_pipeline_id}/presigned-url",
-                presigned_url_query_params=presigned_url_query_params
+                presigned_url_query_params=presigned_url_query_params,
             )
         print("Ground truths published!")

--- a/openlayer/api.py
+++ b/openlayer/api.py
@@ -28,7 +28,6 @@ from requests.adapters import HTTPAdapter, Response, Retry
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 from tqdm import tqdm
 from tqdm.utils import CallbackIOWrapper
-import urllib.parse
 
 from . import constants
 from .exceptions import ExceptionMap, OpenlayerException


### PR DESCRIPTION
# Summary

We now store information related to monitoring data uploads in a way such that we don't need to create InferencePipelineData objects. To accomplish this, we need to request presigned-urls from a separate endpoint specific to inferencePipeline data.

See https://github.com/openlayer-ai/openlayer/pull/1229 for more information.

# Testing

Ran Cid's monitoring quickstart notebook.