### PR TITLE
Bump langchain version for jupyter notebook examples

### DIFF
--- a/examples/llms/langchain/question-answering-with-context/requirements.txt
+++ b/examples/llms/langchain/question-answering-with-context/requirements.txt
@@ -1,7 +1,7 @@
 chroma-hnswlib==0.7.3
 chromadb==0.4.13
 faiss-cpu==1.7.4
-langchain==0.0.302
+langchain>=0.0.308
 openai==0.28.1
 pandas==2.0.3
 tiktoken==0.5.1

--- a/examples/llms/langchain/question-answering/requirements.txt
+++ b/examples/llms/langchain/question-answering/requirements.txt
@@ -1,3 +1,3 @@
-pandas==1.1.4
-langchain
+pandas==2.0.3
+langchain>=0.0.308
 openai


### PR DESCRIPTION
## Summary

- Bumps `langchain` version to resolve dependabot security issue: https://github.com/openlayer-ai/examples-gallery/security/dependabot/135

## Testing

Re-created env and re-ran notebooks that use LangChain.