### PR TITLE
Update llm_monitors to work with openai>=1.0.0

### DIFF
--- a/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
+++ b/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
@@ -116,24 +116,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f7c3dfbc",
-   "metadata": {},
-   "source": [
-    "You can also access all the data accumulated (and in this case, published to Openlayer) with the `data` attribute:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27bb2bdc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "openai_monitor.data"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f9139f2b",


### PR DESCRIPTION
## Summary

- `openai>=1.0.0` has a different Python API ([discussion](https://github.com/openai/openai-python/discussions/742)). Instead of `openai.ChatCompletions.create`, for example, the method of interest is:
```
from openai import OpenAI
client = OpenAI()
client.chat.completions.create(...)
```
- I've updated the `llm_monitors` to work with both versions. This is done by checking the `openai.__version__` and monkey-patching the correct method depending on the case.
- The notebook example was also updated. I added comments indicating how the monitors work for each `openai` version.