### PR TITLE
Update OpenAI model runner to use openai>=1.0.0 and update openai ver…

### DIFF
--- a/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
+++ b/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
@@ -14,6 +14,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "020c8f6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install openlayer"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "75c2a473",
    "metadata": {},
@@ -54,15 +64,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openlayer\n",
     "from openlayer import llm_monitors\n",
     "\n",
-    "# If you're using `openai>=1.0.0`:\n",
     "openai_client = openai.OpenAI()\n",
-    "openai_monitor = llm_monitors.OpenAIMonitor(client=openai_client, publish=True)  # with publish=True, every row gets published to Openlayer automatically\n",
-    "\n",
-    "# Otherwise, use:\n",
-    "# openai_monitor = llm_monitors.OpenAIMonitor(publish=True)  # with publish=True, every row gets published to Openlayer automatically"
+    "openai_monitor = llm_monitors.OpenAIMonitor(client=openai_client, publish=True)  # with publish=True, every row gets published to Openlayer automatically"
    ]
   },
   {
@@ -98,21 +103,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# If you're using `openai>=1.0.0`:\n",
-    "completion = openai_client.chat.completions.create(model=\"gpt-3.5-turbo\",\n",
-    "  messages=[\n",
-    "    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-    "    {\"role\": \"user\", \"content\": \"How are you doing today?\"}\n",
-    "  ])\n",
-    "\n",
-    "# Othwewise, use:\n",
-    "# completion = openai.ChatCompletion.create(\n",
-    "#   model=\"gpt-3.5-turbo\",\n",
-    "#   messages=[\n",
-    "#     {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
-    "#     {\"role\": \"user\", \"content\": \"How are you doing today?\"}\n",
-    "#   ]\n",
-    "# )"
+    "completion = openai_client.chat.completions.create(\n",
+    "    model=\"gpt-3.5-turbo\",\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "        {\"role\": \"user\", \"content\": \"How are you doing today?\"}\n",
+    "    ]\n",
+    ")"
    ]
   },
   {
@@ -128,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "654bb896",
+   "id": "e79ee882",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/openlayer/version.py
+++ b/openlayer/version.py
@@ -22,4 +22,4 @@
          data=data,
       )
 """
-__version__ = "0.1.0a17"
+__version__ = "0.1.0a18"

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ count = True
 max-line-length = 192
 
 [tool:pytest]
-testpaths = 
+testpaths =
     tests
 
 [metadata]
@@ -33,7 +33,7 @@ project_urls =
     Openlayer User Slack Group = https://l.linklyhq.com/l/1DG73
 
 [options]
-packages = 
+packages =
     openlayer
     openlayer.model_runners
     openlayer.model_runners.prediction_jobs
@@ -44,7 +44,7 @@ install_requires =
     jupyter
     marshmallow
     marshmallow_oneofschema
-    openai
+    openai>=1.0.0
     pandas
     pybars3
     requests_toolbelt


### PR DESCRIPTION
…sion required by the client

## Summary
- Pins `openai>=1.0.0` as the required version required by `openlayer`
- `pip install openlayer` in the first cell of the [openai_llm_monitor.ipynb](https://github.com/openlayer-ai/openlayer-python/compare/cid/update-openai-version?expand=1#diff-62f37e1b434f29032e2428038bcd2365d80b8533dd9442230efb2b0af37ed6e8) notebook example (so that it uses `openai==1.0.0`
- Updated the `OpenAIChatCompletionRunner` to use `openai==1.0.0` interface.