### PR TITLE
Remove LLM subtasks in favor of base LLM task type

### DIFF
--- a/examples/llms/ner/entity-extraction.ipynb
+++ b/examples/llms/ner/entity-extraction.ipynb
@@ -453,7 +453,7 @@
     "\n",
     "project = client.create_or_load_project(\n",
     "    name=\"NER with LLMs\",\n",
-    "    task_type=TaskType.LLMNER,\n",
+    "    task_type=TaskType.LLM,\n",
     "    description=\"Evaluating entity extracting LLM.\"\n",
     ")"
    ]

--- a/examples/llms/question-answering/website-faq.ipynb
+++ b/examples/llms/question-answering/website-faq.ipynb
@@ -217,7 +217,7 @@
     "\n",
     "project = client.create_or_load_project(\n",
     "    name=\"QA with LLMs\",\n",
-    "    task_type=TaskType.LLMQuestionAnswering,\n",
+    "    task_type=TaskType.LLM,\n",
     "    description=\"Evaluating an LLM used for QA.\"\n",
     ")"
    ]

--- a/examples/llms/summarization/meeting-notes.ipynb
+++ b/examples/llms/summarization/meeting-notes.ipynb
@@ -396,7 +396,7 @@
     "\n",
     "project = client.create_or_load_project(\n",
     "    name=\"Summarizing with LLMs\",\n",
-    "    task_type=TaskType.LLMSummarization,\n",
+    "    task_type=TaskType.LLM,\n",
     "    description=\"Evaluating an LLM that summarizes meeting notes.\"\n",
     ")"
    ]

--- a/examples/llms/translation/portuguese-translations.ipynb
+++ b/examples/llms/translation/portuguese-translations.ipynb
@@ -229,7 +229,7 @@
     "\n",
     "project = client.create_or_load_project(\n",
     "    name=\"Translation with LLMs\",\n",
-    "    task_type=TaskType.LLMTranslation,\n",
+    "    task_type=TaskType.LLM,\n",
     "    description=\"Evaluating translations with an LLM from En -> Pt.\"\n",
     ")"
    ]


### PR DESCRIPTION
## Summary

- Remove `LLMTranslation`, `LLMNER`, etc. from Jupyter Notebook examples. Using `LLM` instead.