### PR TITLE
Add costColumnName to LLM data schemas and upload cost estimate for O…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+* Added `costColumnName` as an optional field in the config for LLM data.
+
+### Changed
+* `llm_monitor` for OpenAI models now records the `cost` estimate and uploads it.
+
 ## [0.1.0a20]
 
 ### Added

--- a/openlayer/model_runners/ll_model_runners.py
+++ b/openlayer/model_runners/ll_model_runners.py
@@ -441,11 +441,35 @@ class CohereGenerateModelRunner(LLModelRunner):
 class OpenAIChatCompletionRunner(LLModelRunner):
     """Wraps OpenAI's chat completion model."""
 
-    # Last update: 2023-12-19
+    # Last update: 2024-01-05
     COST_PER_TOKEN = {
+        "babbage-002": {
+            "input": 0.0004e-3,
+            "output": 0.0004e-3,
+        },
+        "davinci-002": {
+            "input": 0.002e-3,
+            "output": 0.002e-3,
+        },
+        "gpt-3.5-turbo": {
+            "input": 0.003e-3,
+            "output": 0.006e-3,
+        },
+        "gpt-3.5-turbo-0301": {
+            "input": 0.0015e-3,
+            "output": 0.002e-3,
+        },
+        "gpt-3.5-turbo-0613": {
+            "input": 0.0015e-3,
+            "output": 0.002e-3,
+        },
         "gpt-3.5-turbo-1106": {
             "input": 0.001e-3,
             "output": 0.002e-3,
+        },
+        "gpt-3.5-turbo-16k-0613": {
+            "input": 0.003e-3,
+            "output": 0.004e-3,
         },
         "gpt-3.5-turbo-instruct": {
             "input": 0.0015e-3,
@@ -455,7 +479,23 @@ class OpenAIChatCompletionRunner(LLModelRunner):
             "input": 0.03e-3,
             "output": 0.06e-3,
         },
+        "gpt-4-0314": {
+            "input": 0.03e-3,
+            "output": 0.06e-3,
+        },
+        "gpt-4-1106-preview": {
+            "input": 0.01e-3,
+            "output": 0.03e-3,
+        },
+        "gpt-4-1106-vision-preview": {
+            "input": 0.01e-3,
+            "output": 0.03e-3,
+        },
         "gpt-4-32k": {
+            "input": 0.06e-3,
+            "output": 0.12e-3,
+        },
+        "gpt-4-32k-0314": {
             "input": 0.06e-3,
             "output": 0.12e-3,
         },

--- a/openlayer/schemas/dataset_schemas.py
+++ b/openlayer/schemas/dataset_schemas.py
@@ -104,6 +104,11 @@ class LLMOutputSchema(ma.Schema):
         allow_none=True,
         load_default=None,
     )
+    costColumnName = ma.fields.Str(
+        validate=constants.COLUMN_NAME_VALIDATION_LIST,
+        allow_none=True,
+        load_default=None,
+    )
     numOfTokenColumnName = ma.fields.Str(
         validate=constants.COLUMN_NAME_VALIDATION_LIST,
         allow_none=True,


### PR DESCRIPTION
…penAI LLM monitor

## Summary

- Added `costColumnName` as an optional field for LLM dataset configs.
- For the OpenAI LLM monitor, estimate the cost of each request, log it in a separate column, and upload it to the platform.