### PR TITLE
Add monitor_output_only param to the OpenAI LLM monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+* Added `monitor_output_only` as an argument to the OpenAI `llm_monitor`. If set to `True`, the monitor will only record the output of the model, and not the input.
 * Added `costColumnName` as an optional field in the config for LLM data.
 
 ### Changed


### PR DESCRIPTION
## Summary

- Adds the param `monitor_output_only` to the OpenAI LLM monitor, which defaults to `False`.
- When it is set to `True`, the LLM inputs are not monitored and only the output is logged.
- This method might be helpful in cases where the input variables contain sensitive user data, so the user might choose not to explicitly monitor it.