### PR TITLE
Add openlayer_inference_pipeline_id parameter to the OpenAIMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+* Added `openlayer_inference_pipeline_id` as an optional parameter to the `OpenAIMonitor`. This is an alternative to `openlayer_inference_pipeline_name` and `openlayer_inference_project_name` parameters for identifying the inference pipeline on the platform.
 * Added `monitor_output_only` as an argument to the OpenAI `llm_monitor`. If set to `True`, the monitor will only record the output of the model, and not the input.
 * Added `costColumnName` as an optional field in the config for LLM data.
 


### PR DESCRIPTION
## Summary

- Allows the following usage for the `OpenAIMonitor`:
```python
import os
import openai

# OpenAI env variable
os.environ["OPENAI_API_KEY"] = "sk-..."

# Openlayer env variables
os.environ["OPENLAYER_API_KEY"] = "YOUR_OPENLAYER_API_KEY_HERE"

from openlayer import llm_monitors

openai_client = openai.OpenAI()
openai_monitor = llm_monitors.OpenAIMonitor(
    client=openai_client, 
    publish=True,
    openlayer_inference_pipeline_id="YOUR_INFERENCE_PIPELINE_ID_HERE"
)
```
- By doing so, there's no need to specify the project name nor the inference pipeline name. This way, we avoid making requests to get the inference pipeline id.