### PR TITLE
Completes OPEN-5689 Support streaming for OpenAI Monitor

### DIFF
--- a/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
+++ b/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
@@ -97,6 +97,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "397097b4-aea9-4064-8621-4e0d2077da6d",
+   "metadata": {},
+   "source": [
+    "#### If you call the `create` method with `stream=False` (default):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "e00c1c79",
@@ -112,6 +120,46 @@
     "        {\"role\": \"user\", \"content\": \"I am doing well, but would like some words of encouragement.\"},\n",
     "    ]\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff26b5d-4e86-4863-9f86-5dc98fe51140",
+   "metadata": {},
+   "source": [
+    "#### If you call the `create` method with `stream=True`:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aee9d5c7-496b-48ca-8095-7e79c0753712",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunks = openai_client.chat.completions.create(\n",
+    "    model=\"gpt-3.5-turbo\",\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+    "        {\"role\": \"user\", \"content\": \"How are you doing today?\"},\n",
+    "        {\"role\": \"assistant\", \"content\": \"Pretty well! How about you?\"},\n",
+    "        {\"role\": \"user\", \"content\": \"I am doing well, but would like some words of encouragement.\"},\n",
+    "    ],\n",
+    "    stream=True   \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20d15545-dab2-4763-83f0-6dafb2834886",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Collect the messages from the stream\n",
+    "collected_messages = []\n",
+    "for chunk in chunks:\n",
+    "    collected_messages.append(chunk.choices[0].delta.content)   "
    ]
   },
   {
@@ -149,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

- Adapt the `llm_monitors.OpenAIMonitor` to work when the `create` method has `stream=True`.
- When this is the case, the `create` method returns a generator. 
- The monkey-patched version keeps yielding the chunks -- just like OpenAI does -- but also accumulates the data and some metadata behind the scenes.
- Then, when `finally` is reached, it streams the data to Openlayer.
- The `cost` is actually `completions_cost` and `tokens` is `completion_tokens`. There's currently no reliable way to track prompt tokens/cost. I've uploaded each of these properties "twice" to allow the user to use all the specialized tests we have on these columns, but also transparently see what they represent.
    - I understand this is not ideal. For now, I think this is reasonable, and I'm open to revisiting this in the future. Tracing will force us to modify some of this code, so I can try come up with something better then.
<img width="1313" alt="Screenshot 2024-03-06 at 16 25 52" src="https://github.com/openlayer-ai/openlayer-python/assets/18015306/b3fc870a-802d-4725-b735-ee339ee20f31">

- I'm also keeping track of the `time_to_first_token` in msec.
- Also added a new cell to the quickstart notebook illustrating that our monitor works with `stream=True`.

