### PR TITLE
Add PUBLISH env var to notebook examples

### DIFF
--- a/examples/monitoring/llms/azure-openai/azure_openai_llm_monitor.ipynb
+++ b/examples/monitoring/llms/azure-openai/azure_openai_llm_monitor.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f3f4fa13",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,8 @@
     "\n",
     "# Openlayer env variables\n",
     "os.environ[\"OPENLAYER_API_KEY\"] = \"YOUR_OPENLAYER_API_KEY_HERE\"\n",
-    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\""
+    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\"\n",
+    "os.environ[\"PUBLISH\"] = \"true\" "
    ]
   },
   {
@@ -61,21 +62,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e60584fa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<openlayer.llm_monitors.AzureOpenAIMonitor at 0x7f8758d3abe0>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openlayer import llm_monitors\n",
     "\n",
@@ -108,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e00c1c79",
    "metadata": {},
    "outputs": [],

--- a/examples/monitoring/llms/langchain/langchain_callback.ipynb
+++ b/examples/monitoring/llms/langchain/langchain_callback.ipynb
@@ -46,7 +46,8 @@
     "\n",
     "# Openlayer env variables\n",
     "os.environ[\"OPENLAYER_API_KEY\"] = \"YOUR_OPENLAYER_API_KEY_HERE\"\n",
-    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_PROJECT_NAME_HERE\""
+    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_PROJECT_NAME_HERE\"\n",
+    "os.environ[\"PUBLISH\"] = \"true\" "
    ]
   },
   {

--- a/examples/monitoring/llms/openai-assistant/openai_assistant.ipynb
+++ b/examples/monitoring/llms/openai-assistant/openai_assistant.ipynb
@@ -44,7 +44,8 @@
     "# Set the environment variables\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"YOUR_OPENAI_API_KEY_HERE\"\n",
     "os.environ[\"OPENLAYER_API_KEY\"] = \"YOUR_OPENLAYER_API_KEY_HERE\"\n",
-    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\""
+    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\"\n",
+    "os.environ[\"PUBLISH\"] = \"true\" "
    ]
   },
   {

--- a/examples/monitoring/llms/rag-tracing/rag_tracer.ipynb
+++ b/examples/monitoring/llms/rag-tracing/rag_tracer.ipynb
@@ -26,7 +26,8 @@
     "\n",
     "# Openlayer env variables\n",
     "os.environ[\"OPENLAYER_API_KEY\"] = \"YOUR_OPENLAYER_API_KEY_HERE\"\n",
-    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\" # Where the traces will be uploaded to"
+    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_OPENLAYER_PROJECT_NAME_HERE\" # Where the traces will be uploaded to\n",
+    "os.environ[\"PUBLISH\"] = \"true\" "
    ]
   },
   {

--- a/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
+++ b/examples/monitoring/quickstart/llms/openai_llm_monitor.ipynb
@@ -46,7 +46,8 @@
     "\n",
     "# Openlayer env variables\n",
     "os.environ[\"OPENLAYER_API_KEY\"] = \"YOUR_OPENLAYER_API_KEY_HERE\"\n",
-    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_PROJECT_NAME_HERE\" "
+    "os.environ[\"OPENLAYER_PROJECT_NAME\"] = \"YOUR_PROJECT_NAME_HERE-\" \n",
+    "os.environ[\"PUBLISH\"] = \"true\" "
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Adds the `PUBLISH` env variable to notebook examples that require it. This env var was introduced in the past to control the whether the data should be streamed to Openlayer or not.