### PR TITLE
Fixes OPEN-5957 Completion tokens not being computed by OpenAIMonitor…

### DIFF
--- a/openlayer/llm_monitors.py
+++ b/openlayer/llm_monitors.py
@@ -211,6 +211,8 @@ class OpenAIMonitor:
                             raw_outputs.append(chunk.model_dump())
                             if i == 0:
                                 first_token_time = time.time()
+                            if i > 0:
+                                num_of_completion_tokens = i + 1
 
                             delta = chunk.choices[0].delta
 
@@ -236,8 +238,6 @@ class OpenAIMonitor:
                                     ] += delta.tool_calls[0].function.arguments
 
                             yield chunk
-                        if i > 0:
-                            num_of_completion_tokens = i + 1
                         end_time = time.time()
                         latency = (end_time - start_time) * 1000
                     # pylint: disable=broad-except


### PR DESCRIPTION
… when stream=True

## Summary

- Fixes bug in the wrapper around OpenAI LLMs for when `stream=True`. 
- Because of the bug, the number of completion tokens was not being estimated.