### PR TITLE
Add openlayer.integrations to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ packages =
     openlayer.schemas
     openlayer.validators
     openlayer.tracing
+    openlayer.integrations
 install_requires =
     anthropic
     cohere


### PR DESCRIPTION
## Summary

- Add `openlayer.integrations` to `setup.cfg`
- Otherwise, after `pip` installing `openlayer`, users run into `ModuleNotFound` errors.