### PR TITLE
Async function tracing in dev mode

### DIFF
--- a/src/openlayer/lib/core/base_model.py
+++ b/src/openlayer/lib/core/base_model.py
@@ -1,13 +1,13 @@
 """Base class for an Openlayer model."""
 
-import os
 import abc
-import json
-import time
-import inspect
 import argparse
+import inspect
+import json
+import os
+import time
+from dataclasses import dataclass, field
 from typing import Any, Dict, Tuple
-from dataclasses import field, dataclass
 
 import pandas as pd
 
@@ -42,9 +42,7 @@ class OpenlayerModel(abc.ABC):
     def run_from_cli(self) -> None:
         """Run the model from the command line."""
         parser = argparse.ArgumentParser(description="Run data through a model.")
-        parser.add_argument(
-            "--dataset-path", type=str, required=True, help="Path to the dataset"
-        )
+        parser.add_argument("--dataset-path", type=str, required=True, help="Path to the dataset")
         parser.add_argument(
             "--output-dir",
             type=str,
@@ -85,9 +83,7 @@ class OpenlayerModel(abc.ABC):
             # Filter row_dict to only include keys that are valid parameters
             # for the 'run' method
             row_dict = row.to_dict()
-            filtered_kwargs = {
-                k: v for k, v in row_dict.items() if k in run_signature.parameters
-            }
+            filtered_kwargs = {k: v for k, v in row_dict.items() if k in run_signature.parameters}
 
             # Call the run method with filtered kwargs
             output = self.run(**filtered_kwargs)

--- a/src/openlayer/lib/integrations/langchain_callback.py
+++ b/src/openlayer/lib/integrations/langchain_callback.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=unused-argument
 import time
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from langchain import schema as langchain_schema
 from langchain.callbacks.base import BaseCallbackHandler
@@ -35,9 +35,7 @@ class OpenlayerHandler(BaseCallbackHandler):
         self.metatada: Dict[str, Any] = kwargs or {}
 
     # noqa arg002
-    def on_llm_start(
-        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
-    ) -> Any:
+    def on_llm_start(self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any) -> Any:
         """Run when LLM starts running."""
         pass
 
@@ -81,27 +79,19 @@ class OpenlayerHandler(BaseCallbackHandler):
         """Run on new LLM token. Only available when streaming is enabled."""
         pass
 
-    def on_llm_end(
-        self, response: langchain_schema.LLMResult, **kwargs: Any  # noqa: ARG002, E501
-    ) -> Any:
+    def on_llm_end(self, response: langchain_schema.LLMResult, **kwargs: Any) -> Any:  # noqa: ARG002, E501
         """Run when LLM ends running."""
         self.end_time = time.time()
         self.latency = (self.end_time - self.start_time) * 1000
 
         if response.llm_output and "token_usage" in response.llm_output:
-            self.prompt_tokens = response.llm_output["token_usage"].get(
-                "prompt_tokens", 0
-            )
-            self.completion_tokens = response.llm_output["token_usage"].get(
-                "completion_tokens", 0
-            )
+            self.prompt_tokens = response.llm_output["token_usage"].get("prompt_tokens", 0)
+            self.completion_tokens = response.llm_output["token_usage"].get("completion_tokens", 0)
             self.cost = self._get_cost_estimate(
                 num_input_tokens=self.prompt_tokens,
                 num_output_tokens=self.completion_tokens,
             )
-            self.total_tokens = response.llm_output["token_usage"].get(
-                "total_tokens", 0
-            )
+            self.total_tokens = response.llm_output["token_usage"].get("total_tokens", 0)
 
         for generations in response.generations:
             for generation in generations:
@@ -109,17 +99,12 @@ class OpenlayerHandler(BaseCallbackHandler):
 
         self._add_to_trace()
 
-    def _get_cost_estimate(
-        self, num_input_tokens: int, num_output_tokens: int
-    ) -> float:
+    def _get_cost_estimate(self, num_input_tokens: int, num_output_tokens: int) -> float:
         """Returns the cost estimate for a given model and number of tokens."""
         if self.model not in constants.OPENAI_COST_PER_TOKEN:
             return None
         cost_per_token = constants.OPENAI_COST_PER_TOKEN[self.model]
-        return (
-            cost_per_token["input"] * num_input_tokens
-            + cost_per_token["output"] * num_output_tokens
-        )
+        return cost_per_token["input"] * num_input_tokens + cost_per_token["output"] * num_output_tokens
 
     def _add_to_trace(self) -> None:
         """Adds to the trace."""
@@ -141,15 +126,11 @@ class OpenlayerHandler(BaseCallbackHandler):
             metadata=self.metatada,
         )
 
-    def on_llm_error(
-        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
-    ) -> Any:
+    def on_llm_error(self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any) -> Any:
         """Run when LLM errors."""
         pass
 
-    def on_chain_start(
-        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
-    ) -> Any:
+    def on_chain_start(self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any) -> Any:
         """Run when chain starts running."""
         pass
 
@@ -157,15 +138,11 @@ class OpenlayerHandler(BaseCallbackHandler):
         """Run when chain ends running."""
         pass
 
-    def on_chain_error(
-        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
-    ) -> Any:
+    def on_chain_error(self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any) -> Any:
         """Run when chain errors."""
         pass
 
-    def on_tool_start(
-        self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
-    ) -> Any:
+    def on_tool_start(self, serialized: Dict[str, Any], input_str: str, **kwargs: Any) -> Any:
         """Run when tool starts running."""
         pass
 
@@ -173,9 +150,7 @@ class OpenlayerHandler(BaseCallbackHandler):
         """Run when tool ends running."""
         pass
 
-    def on_tool_error(
-        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
-    ) -> Any:
+    def on_tool_error(self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any) -> Any:
         """Run when tool errors."""
         pass
 
@@ -183,14 +158,10 @@ class OpenlayerHandler(BaseCallbackHandler):
         """Run on arbitrary text."""
         pass
 
-    def on_agent_action(
-        self, action: langchain_schema.AgentAction, **kwargs: Any
-    ) -> Any:
+    def on_agent_action(self, action: langchain_schema.AgentAction, **kwargs: Any) -> Any:
         """Run on agent action."""
         pass
 
-    def on_agent_finish(
-        self, finish: langchain_schema.AgentFinish, **kwargs: Any
-    ) -> Any:
+    def on_agent_finish(self, finish: langchain_schema.AgentFinish, **kwargs: Any) -> Any:
         """Run on agent end."""
         pass

--- a/src/openlayer/lib/integrations/openai_tracer.py
+++ b/src/openlayer/lib/integrations/openai_tracer.py
@@ -1,10 +1,10 @@
 """Module with methods used to trace OpenAI / Azure OpenAI LLMs."""
 
 import json
-import time
 import logging
-from typing import Any, Dict, List, Union, Iterator, Optional
+import time
 from functools import wraps
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import openai
 

--- a/src/openlayer/lib/tracing/steps.py
+++ b/src/openlayer/lib/tracing/steps.py
@@ -4,8 +4,8 @@ import time
 import uuid
 from typing import Any, Dict, Optional
 
-from . import enums
 from .. import utils
+from . import enums
 
 
 class Step:

--- a/src/openlayer/lib/utils.py
+++ b/src/openlayer/lib/utils.py
@@ -2,8 +2,8 @@
 Openlayer SDK.
 """
 
-import os
 import json
+import os
 from typing import Optional
 
 


### PR DESCRIPTION
Adds a `tracer.trace_async()` decorator that needs to be used on async functions. 
Also adds a `tracer.run_async_function` that needs to be used instead of `asyncio.run` when calling an awaitable function.