### PR TITLE
fix: add missing dependencies for LangChain notebook example

### DIFF
--- a/examples/tracing/langchain/langchain_callback.ipynb
+++ b/examples/tracing/langchain/langchain_callback.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install openlayer"
+    "!pip install openlayer langchain langchain_openai"
    ]
   },
   {
@@ -39,7 +39,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import openai\n",
     "\n",
     "# OpenAI env variables\n",
     "os.environ[\"OPENAI_API_KEY\"] = \"YOUR_OPENAI_API_KEY_HERE\"\n",
@@ -92,7 +91,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.messages import HumanMessage\n",
     "from langchain_openai import ChatOpenAI"
    ]
   },
@@ -113,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat.invoke([HumanMessage(content=\"What's the meaning of life?\")])"
+    "chat.invoke(\"What's the meaning of life?\")"
    ]
   },
   {
@@ -149,7 +147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

- Installs `langchain` and `langchain_openai` in the first cell.
- These dependencies are required by the notebook and their absence caused issues when running on Colab.