### PR TITLE
fix: add missing dependency for Anthropic notebook example

### DIFF
--- a/examples/tracing/anthropic/anthropic_tracing.ipynb
+++ b/examples/tracing/anthropic/anthropic_tracing.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install openlayer"
+    "!pip install anthropic openlayer"
    ]
   },
   {


### PR DESCRIPTION
## Summary 

- Adds `anthropic` to the `pip install` cell.
- This dependency is required by the notebook and its absence caused issues when running on Colab.