### PR TITLE
fix: pin pyarrow version to avoid installation issues with latest ver…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "sniffio",
     "cached-property; python_version < '3.8'",
     "pandas; python_version >= '3.7'",
-    "pyarrow>=11.0.0",
+    "pyarrow==11.0.0",
     "pyyaml>=6.0",
     "requests_toolbelt>=1.0.0",
 ]


### PR DESCRIPTION
…sions

## Summary

- The latest versions of `pyarrow` (namely `18.0.0` and `17.0.0`) have installation issues on Python 3.9.
- Pinned `pyarrow==11.0.0` to avoid them.