### PR TITLE
fix: update to pyarrow==14.0.1 to avoid dependabot issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "sniffio",
     "cached-property; python_version < '3.8'",
     "pandas; python_version >= '3.7'",
-    "pyarrow==11.0.0",
+    "pyarrow==14.0.1",
     "pyyaml>=6.0",
     "requests_toolbelt>=1.0.0",
 ]


### PR DESCRIPTION
## Summary

- Upgrade `pyarrow` version required due to Dependabot issue (https://github.com/openlayer-ai/openlayer-python/security/dependabot/13)

