### PR TITLE
chore: update download URL for context file

### DIFF
--- a/examples/tracing/rag/rag_tracing.ipynb
+++ b/examples/tracing/rag/rag_tracing.ipynb
@@ -46,7 +46,7 @@
     "%%bash\n",
     "\n",
     "if [ ! -e \"context.txt\" ]; then\n",
-    "    curl \"https://raw.githubusercontent.com/openlayer-ai/examples-gallery/main/monitoring/llms/rag-tracing/context.txt\" --output \"context.txt\"\n",
+    "    curl \"https://raw.githubusercontent.com/openlayer-ai/templates/refs/heads/main/python/llms/azure-openai-rag/app/model/contexts.txt\" --output \"context.txt\"\n",
     "fi"
    ]
   },
@@ -182,7 +182,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "openlayer-assistant",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Summary

- Updates the URL for the context file (`context.txt`) used by the RAG tracing notebook.
- Previous URL pointed to the `examples-gallery` repo, which is deprecated. 
- Current URL points to the `templates` repo.