### PR TITLE
Cid/async tracing

### DIFF
--- a/src/openlayer/lib/__init__.py
+++ b/src/openlayer/lib/__init__.py
@@ -7,12 +7,15 @@ __all__ = [
     "trace_openai_assistant_thread_run",
     "trace_mistral",
     "trace_groq",
+    "trace_async_openai",
+    "trace_async",
 ]
 
 # ---------------------------------- Tracing --------------------------------- #
 from .tracing import tracer
 
 trace = tracer.trace
+trace_async = tracer.trace_async
 
 
 def trace_anthropic(client):

--- a/src/openlayer/lib/integrations/openai_tracer.py
+++ b/src/openlayer/lib/integrations/openai_tracer.py
@@ -137,9 +137,9 @@ def stream_chunks(
                 if delta.function_call.name:
                     collected_function_call["name"] += delta.function_call.name
                 if delta.function_call.arguments:
-                    collected_function_call["arguments"] += (
-                        delta.function_call.arguments
-                    )
+                    collected_function_call[
+                        "arguments"
+                    ] += delta.function_call.arguments
             elif delta.tool_calls:
                 if delta.tool_calls[0].function.name:
                     collected_function_call["name"] += delta.tool_calls[0].function.name
@@ -257,9 +257,10 @@ def add_to_trace(is_azure_openai: bool = False, **kwargs) -> None:
         tracer.add_chat_completion_step_to_trace(
             **kwargs, name="Azure OpenAI Chat Completion", provider="Azure"
         )
-    tracer.add_chat_completion_step_to_trace(
-        **kwargs, name="OpenAI Chat Completion", provider="OpenAI"
-    )
+    else:
+        tracer.add_chat_completion_step_to_trace(
+            **kwargs, name="OpenAI Chat Completion", provider="OpenAI"
+        )
 
 
 def handle_non_streaming_create(


### PR DESCRIPTION
## Summary

- The `trace_async_openai` wrapper was not working correctly when `stream=True`, raising the error:
```
TypeError: object async_generator can't be used in 'await' expression
```
-  35d02322c5e08170c43d9f617f0210569f11133d fixes this issue, by handling the `AsyncIterator` iterator correctly.
- 37f8ca0bfba968260e7debd6cedb02e181b7703b exposes the `trace_async_openai` and `trace_async` methods at the top level of the lib, so that they can be conveniently imported as in:
```python
from openlayer.lib import trace_async_openai, trace_async
```
- f63d990f36643bee733d586b667b7a5e42fd829a fixes the issue where the Azure OpenAI chat completion steps were added alongside a redundant OpenAI chat completion step.