### PR TITLE
fix(bedrock): accept size positional argument

### DIFF
--- a/src/openlayer/lib/integrations/bedrock_tracer.py
+++ b/src/openlayer/lib/integrations/bedrock_tracer.py
@@ -156,8 +156,11 @@ def handle_non_streaming_invoke(
         )
 
     # Reset response body for return (since we read it)
+    response_bytes = json.dumps(response_data).encode("utf-8")
     response["body"] = type(
-        "MockBody", (), {"read": lambda: json.dumps(response_data).encode("utf-8")}
+        "MockBody",
+        (),
+        {"read": lambda size=-1: response_bytes[:size] if size > 0 else response_bytes},
     )()
     return response
 


### PR DESCRIPTION
# Pull Request

## Summary

The Bedrock tracer was causing a runtime error when customers tried to read the response body after a model invocation.

Updated the `mock read()` method to accept the optional size parameter: `lambda size=-1: response_bytes[:size] if size > 0 else response_bytes`, making it compatible with boto3's `StreamingBody.read()` signature.

This ensures the traced response behaves identically to the original boto3 response for downstream code.
