### PR TITLE
feat: introduce new step types

### DIFF
--- a/src/openlayer/lib/tracing/enums.py
+++ b/src/openlayer/lib/tracing/enums.py
@@ -6,3 +6,7 @@ import enum
 class StepType(enum.Enum):
     USER_CALL = "user_call"
     CHAT_COMPLETION = "chat_completion"
+    AGENT = "agent"
+    RETRIEVER = "retriever"
+    TOOL = "tool"
+    HANDOFF = "handoff"

--- a/src/openlayer/lib/utils.py
+++ b/src/openlayer/lib/utils.py
@@ -48,6 +48,15 @@ def json_serialize(data):
         return [json_serialize(item) for item in data]
     elif isinstance(data, tuple):
         return tuple(json_serialize(item) for item in data)
+    elif isinstance(data, type):
+        # Handle model classes/metaclasses
+        return str(data.__name__ if hasattr(data, "__name__") else data)
+    elif hasattr(data, "model_dump") and callable(getattr(data, "model_dump")):
+        # Handle Pydantic model instances
+        try:
+            return json_serialize(data.model_dump())
+        except Exception:
+            return str(data)
     else:
         # Fallback: Convert to string if not serializable
         try:


### PR DESCRIPTION
# Pull Request

## Summary

Introduces the new step types. Namely `tool`, `agent`, `handoff`, and `retriever`. The new steps types are now used in the LangChain callback handler.

## Changes

- [x] Step schema definition in `steps.py` 
- [x] New step type setup in the LangChain callback handler. 

## Context

POC request.

## Testing

- [x] Manual testing