### PR TITLE
fix: remove numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ dependencies = [
     "pyarrow>=18.0.0; python_version >= '3.9'",
     "pyyaml>=6.0",
     "requests_toolbelt>=1.0.0",
-    "tqdm",
-    "numpy<2"
+    "tqdm"
 ]
 requires-python = ">= 3.8"
 classifiers = [


### PR DESCRIPTION
# Pull Request

## Summary

`numpy` is no longer needed in the SDK. However, we were still pinning it as `numpy<2.0`. This PR removes the version pin.

## Testing

- [x] Manual testing
