### PR TITLE
fix(closes OPEN-10593): openAI parse responses not getting patched

### DIFF
--- a/src/openlayer/lib/integrations/openai_tracer.py
+++ b/src/openlayer/lib/integrations/openai_tracer.py
@@ -150,6 +150,22 @@ def trace_openai(
             )
 
         client.responses.create = traced_responses_create_func
+
+        if hasattr(client.responses, "parse"):
+            responses_parse_func = client.responses.parse
+
+            @wraps(responses_parse_func)
+            def traced_responses_parse_func(*args, **kwargs):
+                inference_id = kwargs.pop("inference_id", None)
+                return handle_responses_non_streaming_create(
+                    *args,
+                    **kwargs,
+                    create_func=responses_parse_func,
+                    inference_id=inference_id,
+                    is_azure_openai=is_azure_openai,
+                )
+
+            client.responses.parse = traced_responses_parse_func
     else:
         logger.debug("Responses API not available in this OpenAI client version")
 


### PR DESCRIPTION
# Pull Request

## Summary

Extends `trace_openai` to also patch `client.responses.parse`, which was previously invisible to tracing. Any call to `responses.parse` (used for structured output via Pydantic models) now produces  a `chat_completion` step in the active trace, consistent with how `responses.create` is already handled.

## Changes

- [x] Added patching of `client.responses.parse` in `trace_openai()` inside `openai_tracer.py`, reusing the existing `handle_responses_non_streaming_create` handler
- [x] Guard with `hasattr(client.responses, "parse")` to maintain compatibility with older SDK versions that may not expose the method

## Context

[OPEN-10593: OpenAI parse responses not getting patched](https://linear.app/openlayer/issue/OPEN-10593/openai-parse-responses-not-getting-patched)

## Testing

- [x] Manual testing
