### PR TITLE
chore(closes OPEN-10613): assign step type in trace decorator

### DIFF
--- a/src/openlayer/lib/tracing/tracer.py
+++ b/src/openlayer/lib/tracing/tracer.py
@@ -573,6 +573,12 @@ def trace(
             step_kwargs["name"] = func.__name__
         step_name = step_kwargs["name"]
 
+        _raw_step_type = step_kwargs.get("step_type", enums.StepType.USER_CALL)
+        if isinstance(_raw_step_type, str):
+            _raw_step_type = enums.StepType(_raw_step_type)
+        step_type = _raw_step_type
+        step_kwargs["step_type"] = step_type
+
         # Check if it's a generator function
         if inspect.isgeneratorfunction(func):
             # For sync generators, use class-based approach to delay trace creation
@@ -601,7 +607,7 @@ def trace(
                             self._step, self._is_root_step, self._token = (
                                 _create_and_initialize_step(
                                     step_name=step_name,
-                                    step_type=enums.StepType.USER_CALL,
+                                    step_type=step_type,
                                     inputs=None,
                                     output=None,
                                     metadata=None,
@@ -847,6 +853,12 @@ def trace_async(
             step_kwargs["name"] = func.__name__
         step_name = step_kwargs["name"]
 
+        _raw_step_type = step_kwargs.get("step_type", enums.StepType.USER_CALL)
+        if isinstance(_raw_step_type, str):
+            _raw_step_type = enums.StepType(_raw_step_type)
+        step_type = _raw_step_type
+        step_kwargs["step_type"] = step_type
+
         if asyncio.iscoroutinefunction(func) or inspect.isasyncgenfunction(func):
             # Check if it's specifically an async generator function
             if inspect.isasyncgenfunction(func):
@@ -873,7 +885,7 @@ def trace_async(
                                 self._step, self._is_root_step, self._token = (
                                     _create_and_initialize_step(
                                         step_name=step_name,
-                                        step_type=enums.StepType.USER_CALL,
+                                        step_type=step_type,
                                         inputs=None,
                                         output=None,
                                         metadata=None,
@@ -1772,6 +1784,9 @@ def _process_wrapper_inputs_and_outputs(
         context_kwarg=context_kwarg,
         question_kwarg=question_kwarg,
     )
+    if isinstance(step, steps.ToolStep):
+        step.function_name = step.name
+        step.arguments = inputs
     _finalize_step_logging(
         step=step,
         inputs=inputs,


### PR DESCRIPTION
# Pull Request

## Summary

Allows step type assignment via the `trace` decorator.

## Changes

- [x] Forward `step_type` if passed in as a `trace` decorator kwarg.

## Context

[OPEN-10613: Assign step type in trace decorator](https://linear.app/openlayer/issue/OPEN-10613/assign-step-type-in-trace-decorator)

## Testing

- [x] Manual testing
