### PR TITLE
feat(closes OPEN-10364): make tracers init-based

### DIFF
--- a/src/openlayer/lib/__init__.py
+++ b/src/openlayer/lib/__init__.py
@@ -4,6 +4,8 @@ __all__ = [
     "init",
     "configure",
     "get_tracer_config",
+    "auto_instrument",
+    "unpatch_all",
     "trace",
     "trace_anthropic",
     "trace_openai",
@@ -44,6 +46,7 @@ from .tracing.context import (
     get_current_session_id,
     clear_user_session_context,
 )
+from .integrations._auto import auto_instrument, unpatch_all
 
 init = tracer.init
 configure = tracer.configure

--- a/src/openlayer/lib/integrations/_auto.py
+++ b/src/openlayer/lib/integrations/_auto.py
@@ -138,6 +138,12 @@ REGISTRY: Tuple[IntegrationSpec, ...] = (
         _patch_via("groq_tracer", "_patch_groq"),
         _patch_via("groq_tracer", "_unpatch_groq"),
     ),
+    # TODO: This targets the LEGACY Google Generative AI SDK (package
+    # `google-generativeai`, module `google.generativeai`), which is in
+    # maintenance mode. The new Google Gen AI SDK (package `google-genai`,
+    # module `google.genai`, client `genai.Client()`) is NOT yet covered —
+    # users on it get no auto-instrumentation. Follow-up: add a
+    # google_genai_tracer and register a second entry probing `google.genai`.
     IntegrationSpec(
         "gemini",
         "google.generativeai",
@@ -166,7 +172,7 @@ REGISTRY: Tuple[IntegrationSpec, ...] = (
         "portkey",
         "portkey_ai",
         _patch_via("portkey_tracer", "trace_portkey"),
-        None,
+        _patch_via("portkey_tracer", "_unpatch_portkey"),
     ),
     IntegrationSpec(
         "google_adk",

--- a/src/openlayer/lib/integrations/_auto.py
+++ b/src/openlayer/lib/integrations/_auto.py
@@ -1,0 +1,258 @@
+"""Auto-instrumentation registry and orchestrator.
+
+This module powers ``openlayer.lib.init(auto_instrument=True)`` — when called,
+it walks a registry of supported LLM SDK integrations, detects which ones are
+installed (via ``importlib.util.find_spec``), and applies their patch function
+so that every newly-constructed client is auto-traced.
+
+The two helper functions ``_patch_class_init`` and ``_unpatch_class_init`` are
+the shared patch/unpatch primitives used by each ``<x>_tracer.py`` module to
+wrap an SDK's client class ``__init__``. They are idempotent and reversible.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import importlib.util
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+logger = logging.getLogger(__name__)
+
+
+# Attribute marker placed on a client *class* once its __init__ has been
+# wrapped. Distinct from `_openlayer_patched` which marks individual *instances*
+# after a per-client wrap. Both are needed: the class marker prevents re-wrapping
+# __init__, the instance marker prevents re-wrapping methods if the user mixes
+# auto-instrument with an explicit trace_<x>(client) call on the same instance.
+_CLASS_PATCHED_ATTR = "_openlayer_class_patched"
+
+
+def _patch_class_init(
+    cls: Type[Any],
+    wrap_fn: Callable[[Any], Any],
+) -> None:
+    """Wrap ``cls.__init__`` so every newly-constructed instance is auto-traced.
+
+    Idempotent: re-applying on an already-patched class is a no-op. The wrap
+    failure is caught and logged so a broken integration doesn't break client
+    construction.
+    """
+    if getattr(cls, _CLASS_PATCHED_ATTR, False):
+        return
+
+    original_init = cls.__init__
+
+    @functools.wraps(original_init)
+    def wrapped_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        original_init(self, *args, **kwargs)
+        try:
+            wrap_fn(self)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                "Openlayer: failed to auto-trace %s instance: %s",
+                cls.__name__,
+                e,
+            )
+
+    cls.__init__ = wrapped_init  # type: ignore[method-assign]
+    setattr(cls, _CLASS_PATCHED_ATTR, True)
+
+
+def _unpatch_class_init(cls: Type[Any]) -> None:
+    """Restore the original ``cls.__init__``. No-op if not patched."""
+    if not getattr(cls, _CLASS_PATCHED_ATTR, False):
+        return
+    wrapped = cls.__init__
+    original = getattr(wrapped, "__wrapped__", None)
+    if original is not None:
+        cls.__init__ = original  # type: ignore[method-assign]
+    try:
+        delattr(cls, _CLASS_PATCHED_ATTR)
+    except AttributeError:
+        pass
+
+
+@dataclass(frozen=True)
+class IntegrationSpec:
+    """Declarative entry in the auto-instrumentation registry."""
+
+    name: str
+    """Public name users pass in ``auto_instrument=[...]``."""
+
+    probe: str
+    """Top-level package name used with ``importlib.util.find_spec`` to detect
+    whether the SDK is installed. Only the first dotted segment is probed."""
+
+    patch: Callable[[], None]
+    """Idempotent function that patches the SDK's client class(es)."""
+
+    unpatch: Optional[Callable[[], None]] = None
+    """Optional restorer. Some integrations (litellm, portkey) don't have one
+    today; they're still registered so the patch path works."""
+
+
+# ----------------------------- Lazy import helpers ----------------------------- #
+#
+# The registry uses lambdas that import the tracer module on first call. This
+# keeps the import-time cost of `openlayer.lib` low — we don't load every
+# LLM SDK's tracer module just because the user did `from openlayer.lib import init`.
+
+
+def _patch_via(module_name: str, attr: str) -> Callable[[], None]:
+    """Return a lazy patcher: imports ``.<module_name>`` and calls its ``attr``."""
+
+    def _do_patch() -> None:
+        mod = importlib.import_module(f".{module_name}", package=__package__)
+        getattr(mod, attr)()
+
+    return _do_patch
+
+
+# ----------------------------- Registry ----------------------------- #
+
+REGISTRY: Tuple[IntegrationSpec, ...] = (
+    IntegrationSpec(
+        "openai",
+        "openai",
+        _patch_via("openai_tracer", "_patch_openai"),
+        _patch_via("openai_tracer", "_unpatch_openai"),
+    ),
+    IntegrationSpec(
+        "anthropic",
+        "anthropic",
+        _patch_via("anthropic_tracer", "_patch_anthropic"),
+        _patch_via("anthropic_tracer", "_unpatch_anthropic"),
+    ),
+    IntegrationSpec(
+        "mistral",
+        "mistralai",
+        _patch_via("mistral_tracer", "_patch_mistral"),
+        _patch_via("mistral_tracer", "_unpatch_mistral"),
+    ),
+    IntegrationSpec(
+        "groq",
+        "groq",
+        _patch_via("groq_tracer", "_patch_groq"),
+        _patch_via("groq_tracer", "_unpatch_groq"),
+    ),
+    IntegrationSpec(
+        "gemini",
+        "google.generativeai",
+        _patch_via("gemini_tracer", "_patch_gemini"),
+        _patch_via("gemini_tracer", "_unpatch_gemini"),
+    ),
+    IntegrationSpec(
+        "oci",
+        "oci",
+        _patch_via("oci_tracer", "_patch_oci"),
+        _patch_via("oci_tracer", "_unpatch_oci"),
+    ),
+    IntegrationSpec(
+        "azure_content_understanding",
+        "azure.ai.contentunderstanding",
+        _patch_via("azure_content_understanding_tracer", "_patch_acu"),
+        _patch_via("azure_content_understanding_tracer", "_unpatch_acu"),
+    ),
+    IntegrationSpec(
+        "litellm",
+        "litellm",
+        _patch_via("litellm_tracer", "trace_litellm"),
+        None,
+    ),
+    IntegrationSpec(
+        "portkey",
+        "portkey_ai",
+        _patch_via("portkey_tracer", "trace_portkey"),
+        None,
+    ),
+    IntegrationSpec(
+        "google_adk",
+        "google.adk",
+        _patch_via("google_adk_tracer", "trace_google_adk"),
+        _patch_via("google_adk_tracer", "unpatch_google_adk"),
+    ),
+)
+
+
+_REGISTRY_BY_NAME: Dict[str, IntegrationSpec] = {s.name: s for s in REGISTRY}
+
+
+def _is_installed(probe: str) -> bool:
+    """Return True if the full dotted ``probe`` path is importable.
+
+    Uses ``find_spec`` so the SDK itself is not imported at probe time — only
+    the patch function imports it, and only when we've committed to patching.
+    The full path matters for namespace-package collisions: e.g. ``google``
+    can be installed via ``google.generativeai`` without ``google.adk`` being
+    available, so we have to probe ``google.adk`` not just ``google``.
+    """
+    try:
+        return importlib.util.find_spec(probe) is not None
+    except (ImportError, ValueError, ModuleNotFoundError):
+        return False
+
+
+def auto_instrument(
+    targets: Union[bool, List[str]] = True,
+) -> Dict[str, bool]:
+    """Detect and patch installed LLM SDKs so new client instances are auto-traced.
+
+    Args:
+        targets: ``True`` (default) patches every installed supported SDK.
+            ``False`` is a no-op. A list of names patches only that subset
+            (e.g. ``["openai", "anthropic"]``).
+
+    Returns:
+        Dict mapping integration name to a boolean: ``True`` if patched
+        successfully, ``False`` if skipped (not installed, or patch raised).
+    """
+    if targets is False:
+        return {}
+
+    if targets is True:
+        enabled = {s.name for s in REGISTRY}
+    else:
+        enabled = set(targets)
+        unknown = enabled - set(_REGISTRY_BY_NAME)
+        if unknown:
+            logger.warning(
+                "Openlayer: unknown auto_instrument targets: %s",
+                sorted(unknown),
+            )
+            enabled &= set(_REGISTRY_BY_NAME)
+
+    results: Dict[str, bool] = {}
+    for spec in REGISTRY:
+        if spec.name not in enabled:
+            continue
+        if not _is_installed(spec.probe):
+            results[spec.name] = False
+            logger.debug("Openlayer: skipped %s (not installed)", spec.name)
+            continue
+        try:
+            spec.patch()
+            results[spec.name] = True
+            logger.info("Openlayer: auto-instrumented %s", spec.name)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Openlayer: failed to instrument %s: %s", spec.name, e)
+            results[spec.name] = False
+    return results
+
+
+def unpatch_all() -> None:
+    """Restore the original ``__init__`` for every patched integration.
+
+    Integrations without an unpatch function are skipped. After this call,
+    previously-constructed (and already-traced) client instances are unaffected
+    — only future construction goes through the restored ``__init__``.
+    """
+    for spec in REGISTRY:
+        if spec.unpatch is None:
+            continue
+        try:
+            spec.unpatch()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Openlayer: failed to unpatch %s: %s", spec.name, e)

--- a/src/openlayer/lib/integrations/anthropic_tracer.py
+++ b/src/openlayer/lib/integrations/anthropic_tracer.py
@@ -53,7 +53,10 @@ def trace_anthropic(
         raise ImportError(
             "Anthropic library is not installed. Please install it with: pip install anthropic"
         )
-    
+
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     create_func = client.messages.create
 
     @wraps(create_func)
@@ -76,7 +79,35 @@ def trace_anthropic(
         )
 
     client.messages.create = traced_create_func
+    client._openlayer_patched = True
     return client
+
+
+def _patch_anthropic() -> None:
+    """Patch ``anthropic.Anthropic`` (and async variant if available) ``__init__``
+    so every newly-constructed instance is auto-traced. Idempotent."""
+    if not HAVE_ANTHROPIC:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(anthropic.Anthropic, trace_anthropic)
+    # Async variant: patch only if it exists in this anthropic version.
+    async_cls = getattr(anthropic, "AsyncAnthropic", None)
+    if async_cls is not None:
+        _patch_class_init(async_cls, trace_anthropic)
+
+
+def _unpatch_anthropic() -> None:
+    if not HAVE_ANTHROPIC:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(anthropic.Anthropic)
+    async_cls = getattr(anthropic, "AsyncAnthropic", None)
+    if async_cls is not None:
+        _unpatch_class_init(async_cls)
 
 
 def handle_streaming_create(

--- a/src/openlayer/lib/integrations/async_openai_tracer.py
+++ b/src/openlayer/lib/integrations/async_openai_tracer.py
@@ -71,6 +71,9 @@ def trace_async_openai(
     if not HAVE_OPENAI:
         raise ImportError("OpenAI library is not installed. Please install it with: pip install openai")
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     is_azure_openai = isinstance(client, openai.AsyncAzureOpenAI)
 
     # Patch Chat Completions API
@@ -174,6 +177,7 @@ def trace_async_openai(
 
         client.embeddings.create = traced_embeddings_create_func
 
+    client._openlayer_patched = True
     return client
 
 

--- a/src/openlayer/lib/integrations/azure_content_understanding_tracer.py
+++ b/src/openlayer/lib/integrations/azure_content_understanding_tracer.py
@@ -57,6 +57,9 @@ def trace_azure_content_understanding(
             "Please install it with: pip install azure-ai-contentunderstanding"
         )
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     begin_analyze_func = client.begin_analyze
 
     @wraps(begin_analyze_func)
@@ -109,7 +112,28 @@ def trace_azure_content_understanding(
         return poller
 
     client.begin_analyze = traced_begin_analyze
+    client._openlayer_patched = True
     return client
+
+
+def _patch_acu() -> None:
+    """Patch ``azure.ai.contentunderstanding.ContentUnderstandingClient.__init__``
+    so every newly-constructed client is auto-traced. Idempotent."""
+    if not HAVE_AZURE_CONTENT_UNDERSTANDING:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(ContentUnderstandingClient, trace_azure_content_understanding)
+
+
+def _unpatch_acu() -> None:
+    if not HAVE_AZURE_CONTENT_UNDERSTANDING:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(ContentUnderstandingClient)
 
 
 def _extract_usage_from_poller(poller: Any) -> Dict[str, Any]:

--- a/src/openlayer/lib/integrations/bedrock_tracer.py
+++ b/src/openlayer/lib/integrations/bedrock_tracer.py
@@ -61,6 +61,9 @@ def trace_bedrock(client: "boto3.client") -> "boto3.client":
             "boto3 library is not installed. Please install it with: pip install boto3"
         )
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     # Patch invoke_model for non-streaming requests
     invoke_model_func = client.invoke_model
     invoke_model_stream_func = client.invoke_model_with_response_stream
@@ -95,6 +98,7 @@ def trace_bedrock(client: "boto3.client") -> "boto3.client":
 
     client.invoke_model = traced_invoke_model
     client.invoke_model_with_response_stream = traced_invoke_model_stream
+    client._openlayer_patched = True
     return client
 
 

--- a/src/openlayer/lib/integrations/gemini_tracer.py
+++ b/src/openlayer/lib/integrations/gemini_tracer.py
@@ -1,4 +1,13 @@
-"""Module with methods used to trace Google Gemini LLMs."""
+"""Module with methods used to trace Google Gemini LLMs.
+
+NOTE: This targets the LEGACY Google Generative AI SDK only — package
+``google-generativeai``, module ``google.generativeai``, client
+``genai.GenerativeModel``. That SDK is in maintenance mode. The new Google
+Gen AI SDK (package ``google-genai``, module ``google.genai``, client
+``genai.Client()`` with ``client.models.generate_content``) is NOT handled
+here and is not auto-instrumented; supporting it needs a separate tracer +
+registry entry (see the TODO in ``_auto.py``).
+"""
 
 import json
 import logging

--- a/src/openlayer/lib/integrations/gemini_tracer.py
+++ b/src/openlayer/lib/integrations/gemini_tracer.py
@@ -73,6 +73,9 @@ def trace_gemini(
             "Google Generative AI library is not installed. Please install it with: pip install google-generativeai"
         )
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     # Store original methods
     original_generate_content = client.generate_content
     original_generate_content_async = client.generate_content_async
@@ -125,7 +128,28 @@ def trace_gemini(
     client.generate_content = traced_generate_content
     client.generate_content_async = traced_generate_content_async
 
+    client._openlayer_patched = True
     return client
+
+
+def _patch_gemini() -> None:
+    """Patch ``google.generativeai.GenerativeModel.__init__`` so every newly-
+    constructed model is auto-traced. Idempotent."""
+    if not HAVE_GEMINI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(genai.GenerativeModel, trace_gemini)
+
+
+def _unpatch_gemini() -> None:
+    if not HAVE_GEMINI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(genai.GenerativeModel)
 
 
 def handle_streaming_generate(

--- a/src/openlayer/lib/integrations/google_adk_tracer.py
+++ b/src/openlayer/lib/integrations/google_adk_tracer.py
@@ -58,6 +58,11 @@ _original_callbacks: Dict[str, Any] = {}
 # Track wrapped methods for cleanup
 _wrapped_methods = []
 
+# Module-level idempotency guard. _patch_google_adk() wraps many methods via
+# wrapt; without this, a second call (e.g. a repeated init(auto_instrument=True))
+# would stack a wrapper layer on every ADK method. Reset by _unpatch_google_adk().
+_google_adk_patched = False
+
 # Context variable to store the current user query across nested calls
 _current_user_query: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "google_adk_user_query", default=None
@@ -1536,6 +1541,11 @@ def _patch_google_adk() -> None:
     Reference:
         ADK Telemetry: https://github.com/google/adk-python/tree/main/src/google/adk/telemetry
     """
+    global _google_adk_patched
+    if _google_adk_patched:
+        logger.debug("Google ADK already patched; skipping (idempotent).")
+        return
+
     logger.debug("Applying Google ADK patches for Openlayer instrumentation")
 
     # Only disable ADK's tracer if explicitly requested
@@ -1595,6 +1605,8 @@ def _patch_google_adk() -> None:
     # Patch tool execution
     _patch_module_function("google.adk.flows.llm_flows.functions", "__call_tool_async", _call_tool_async_wrapper)
 
+    _google_adk_patched = True
+
     if _disable_adk_otel_tracing:
         logger.info("Google ADK patching complete. ADK's OTel tracing disabled, using Openlayer only.")
     else:
@@ -1611,7 +1623,7 @@ def _unpatch_google_adk() -> None:
     - Removes all method patches
     - Clears stored original callbacks
     """
-    global _disable_adk_otel_tracing
+    global _disable_adk_otel_tracing, _google_adk_patched
 
     logger.debug("Removing Google ADK patches")
 
@@ -1641,7 +1653,8 @@ def _unpatch_google_adk() -> None:
     # Clear stored original callbacks
     _original_callbacks.clear()
 
-    # Reset the flag
+    # Reset the flags so a subsequent trace_google_adk() re-patches cleanly
     _disable_adk_otel_tracing = False
+    _google_adk_patched = False
 
     logger.info("Google ADK unpatching complete")

--- a/src/openlayer/lib/integrations/groq_tracer.py
+++ b/src/openlayer/lib/integrations/groq_tracer.py
@@ -53,7 +53,10 @@ def trace_groq(
         raise ImportError(
             "Groq library is not installed. Please install it with: pip install groq"
         )
-    
+
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     create_func = client.chat.completions.create
 
     @wraps(create_func)
@@ -76,7 +79,34 @@ def trace_groq(
         )
 
     client.chat.completions.create = traced_create_func
+    client._openlayer_patched = True
     return client
+
+
+def _patch_groq() -> None:
+    """Patch ``groq.Groq.__init__`` (and ``AsyncGroq`` if available) so every
+    newly-constructed instance is auto-traced. Idempotent."""
+    if not HAVE_GROQ:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(groq.Groq, trace_groq)
+    async_cls = getattr(groq, "AsyncGroq", None)
+    if async_cls is not None:
+        _patch_class_init(async_cls, trace_groq)
+
+
+def _unpatch_groq() -> None:
+    if not HAVE_GROQ:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(groq.Groq)
+    async_cls = getattr(groq, "AsyncGroq", None)
+    if async_cls is not None:
+        _unpatch_class_init(async_cls)
 
 
 def handle_streaming_create(

--- a/src/openlayer/lib/integrations/mistral_tracer.py
+++ b/src/openlayer/lib/integrations/mistral_tracer.py
@@ -53,7 +53,10 @@ def trace_mistral(
         raise ImportError(
             "Mistral library is not installed. Please install it with: pip install mistralai"
         )
-    
+
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     stream_func = client.chat.stream
     create_func = client.chat.complete
 
@@ -80,7 +83,28 @@ def trace_mistral(
     client.chat.stream = traced_stream_func
     client.chat.complete = traced_create_func
 
+    client._openlayer_patched = True
     return client
+
+
+def _patch_mistral() -> None:
+    """Patch ``mistralai.Mistral.__init__`` so every newly-constructed instance is
+    auto-traced. Idempotent."""
+    if not HAVE_MISTRAL:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(mistralai.Mistral, trace_mistral)
+
+
+def _unpatch_mistral() -> None:
+    if not HAVE_MISTRAL:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(mistralai.Mistral)
 
 
 def handle_streaming_create(

--- a/src/openlayer/lib/integrations/oci_tracer.py
+++ b/src/openlayer/lib/integrations/oci_tracer.py
@@ -59,6 +59,9 @@ def trace_oci_genai(
     if not HAVE_OCI:
         raise ImportError("oci library is not installed. Please install it with: pip install oci")
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     chat_func = client.chat
 
     @wraps(chat_func)
@@ -100,7 +103,28 @@ def trace_oci_genai(
             )
 
     client.chat = traced_chat_func
+    client._openlayer_patched = True
     return client
+
+
+def _patch_oci() -> None:
+    """Patch ``oci.generative_ai_inference.GenerativeAiInferenceClient.__init__``
+    so every newly-constructed client is auto-traced. Idempotent."""
+    if not HAVE_OCI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+
+    _patch_class_init(GenerativeAiInferenceClient, trace_oci_genai)
+
+
+def _unpatch_oci() -> None:
+    if not HAVE_OCI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(GenerativeAiInferenceClient)
 
 
 def handle_streaming_chat(

--- a/src/openlayer/lib/integrations/openai_tracer.py
+++ b/src/openlayer/lib/integrations/openai_tracer.py
@@ -70,6 +70,9 @@ def trace_openai(
             "OpenAI library is not installed. Please install it with: pip install openai"
         )
 
+    if getattr(client, "_openlayer_patched", False) is True:
+        return client
+
     is_azure_openai = isinstance(client, openai.AzureOpenAI)
 
     # Patch Chat Completions API
@@ -187,7 +190,34 @@ def trace_openai(
 
         client.embeddings.create = traced_embeddings_create_func
 
+    client._openlayer_patched = True
     return client
+
+
+def _patch_openai() -> None:
+    """Patch ``openai.OpenAI`` / ``AzureOpenAI`` / ``AsyncOpenAI`` / ``AsyncAzureOpenAI``
+    ``__init__`` so every newly-constructed instance is auto-traced. Idempotent."""
+    if not HAVE_OPENAI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
+    from .async_openai_tracer import trace_async_openai
+
+    _patch_class_init(openai.OpenAI, trace_openai)
+    _patch_class_init(openai.AzureOpenAI, trace_openai)
+    _patch_class_init(openai.AsyncOpenAI, trace_async_openai)
+    _patch_class_init(openai.AsyncAzureOpenAI, trace_async_openai)
+
+
+def _unpatch_openai() -> None:
+    """Restore the original ``__init__`` on every OpenAI client class."""
+    if not HAVE_OPENAI:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    for cls in (openai.OpenAI, openai.AzureOpenAI, openai.AsyncOpenAI, openai.AsyncAzureOpenAI):
+        _unpatch_class_init(cls)
 
 
 def handle_streaming_create(

--- a/src/openlayer/lib/integrations/portkey_tracer.py
+++ b/src/openlayer/lib/integrations/portkey_tracer.py
@@ -66,56 +66,72 @@ def trace_portkey() -> None:
             "Portkey library is not installed. Please install it with: pip install portkey-ai"
         )
 
-    # Patch instances on initialization rather than class-level attributes.
-    # Some SDKs initialize 'chat' lazily on the instance.
-    original_init = Portkey.__init__
+    # Patch instances on initialization rather than class-level attributes
+    # (some SDKs initialize 'chat' lazily on the instance). Routed through the
+    # shared _patch_class_init helper so it inherits the class-level idempotency
+    # guard — calling trace_portkey() (or init()) repeatedly does not stack
+    # wrappers on Portkey.__init__.
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _patch_class_init
 
-    @wraps(original_init)
-    def traced_init(self, *args, **kwargs):
-        original_init(self, *args, **kwargs)
-        try:
-            # Avoid double-patching
-            if getattr(self, "_openlayer_portkey_patched", False):
-                return
-            # Access chat to ensure it's constructed, then wrap create
-            chat = getattr(self, "chat", None)
-            if chat is None or not hasattr(chat, "completions") or not hasattr(chat.completions, "create"):
-                # If the structure isn't present, skip gracefully and log diagnostics
-                logger.debug(
-                    "Openlayer Portkey tracer: Portkey client missing expected attributes (chat/completions/create). "
-                    "Tracing not applied for this instance."
-                )
-                return
-            original_create = chat.completions.create
+    _patch_class_init(Portkey, _wrap_portkey_instance)
 
-            @wraps(original_create)
-            def traced_create(*c_args, **c_kwargs):
-                inference_id = c_kwargs.pop("inference_id", None)
-                stream = c_kwargs.get("stream", False)
-                if stream:
-                    return handle_streaming_create(
-                        self,
-                        *c_args,
-                        create_func=original_create,
-                        inference_id=inference_id,
-                        **c_kwargs,
-                    )
-                return handle_non_streaming_create(
-                    self,
+
+def _wrap_portkey_instance(client: "Portkey") -> "Portkey":
+    """Wrap a Portkey client instance's chat.completions.create for tracing.
+
+    Idempotent per instance via the ``_openlayer_portkey_patched`` marker. Skips
+    gracefully (with a debug log) when the client lacks the expected structure.
+    """
+    try:
+        if getattr(client, "_openlayer_portkey_patched", False):
+            return client
+        # Access chat to ensure it's constructed, then wrap create
+        chat = getattr(client, "chat", None)
+        if chat is None or not hasattr(chat, "completions") or not hasattr(chat.completions, "create"):
+            logger.debug(
+                "Openlayer Portkey tracer: Portkey client missing expected attributes (chat/completions/create). "
+                "Tracing not applied for this instance."
+            )
+            return client
+        original_create = chat.completions.create
+
+        @wraps(original_create)
+        def traced_create(*c_args, **c_kwargs):
+            inference_id = c_kwargs.pop("inference_id", None)
+            stream = c_kwargs.get("stream", False)
+            if stream:
+                return handle_streaming_create(
+                    client,
                     *c_args,
                     create_func=original_create,
                     inference_id=inference_id,
                     **c_kwargs,
                 )
+            return handle_non_streaming_create(
+                client,
+                *c_args,
+                create_func=original_create,
+                inference_id=inference_id,
+                **c_kwargs,
+            )
 
-            self.chat.completions.create = traced_create
-            setattr(self, "_openlayer_portkey_patched", True)
-            logger.debug("Openlayer Portkey tracer: successfully patched Portkey client instance for tracing.")
-        except Exception as e:
-            logger.debug("Failed to patch Portkey client instance for tracing: %s", e)
+        client.chat.completions.create = traced_create
+        setattr(client, "_openlayer_portkey_patched", True)
+        logger.debug("Openlayer Portkey tracer: successfully patched Portkey client instance for tracing.")
+    except Exception as e:
+        logger.debug("Failed to patch Portkey client instance for tracing: %s", e)
+    return client
 
-    Portkey.__init__ = traced_init
-    logger.info("Openlayer Portkey tracer: tracing enabled (instance-level patch).")
+
+def _unpatch_portkey() -> None:
+    """Restore Portkey.__init__ to its original. No-op if not patched."""
+    if not HAVE_PORTKEY:
+        return
+    # pylint: disable=import-outside-toplevel
+    from ._auto import _unpatch_class_init
+
+    _unpatch_class_init(Portkey)
 
 
 def handle_streaming_create(

--- a/src/openlayer/lib/tracing/tracer.py
+++ b/src/openlayer/lib/tracing/tracer.py
@@ -147,6 +147,7 @@ def init(
     attachment_upload_enabled: Any = _UNSET,
     url_upload_enabled: Any = _UNSET,
     background_publish_enabled: Any = _UNSET,
+    auto_instrument: Union[bool, List[str]] = True,
 ) -> None:
     """Initialize and configure the Openlayer tracer.
 
@@ -188,6 +189,14 @@ def init(
             platform has a durable copy. Defaults to False.
         background_publish_enabled: Publish traces from a background thread so the
             main thread returns immediately. Defaults to True.
+        auto_instrument: When truthy (default ``True``), detects every installed
+            supported LLM SDK (openai, anthropic, mistral, groq, gemini, oci,
+            azure_content_understanding, litellm, portkey, google_adk) and patches
+            it so newly-constructed clients are auto-traced. Pass ``False`` to skip
+            patching, or a list of names (e.g. ``["openai", "anthropic"]``) to
+            patch only that subset. This is a procedural argument — it is NOT
+            persisted across calls, and ``False`` does not unpatch (use
+            :func:`openlayer.lib.unpatch_all` for that).
 
     Examples:
         >>> from openlayer.lib import init, trace
@@ -231,6 +240,13 @@ def init(
 
     reset_uploader()
 
+    # Run auto-instrumentation. The patchers themselves are idempotent, so
+    # repeated init() calls are safe. False short-circuits entirely.
+    if auto_instrument is not False:
+        from ..integrations._auto import auto_instrument as _run_auto_instrument
+
+        _run_auto_instrument(auto_instrument)
+
 
 # Track that the configure() deprecation log has been emitted once per process
 # so we don't spam logs on repeated calls.
@@ -259,6 +275,10 @@ def configure(**kwargs: Any) -> None:
             "openlayer.lib.configure() is deprecated; use openlayer.lib.init() instead."
         )
         _configure_deprecation_logged = True
+    # Preserve the historical configure() behavior of NOT auto-instrumenting —
+    # users who haven't migrated to init() should not be surprised by sudden
+    # client patching on SDK upgrade.
+    kwargs.setdefault("auto_instrument", False)
     init(**kwargs)
 
 

--- a/tests/test_google_adk_integration.py
+++ b/tests/test_google_adk_integration.py
@@ -41,6 +41,17 @@ def _disable_publish(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_tracer, "_publish", False, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _reset_adk_patch_state():
+    """Unpatch ADK after each test so the module-level idempotency flag
+    (``_google_adk_patched``) doesn't leak between tests and turn a later
+    ``trace_google_adk()`` into a silent no-op."""
+    yield
+    from openlayer.lib.integrations.google_adk_tracer import _unpatch_google_adk
+
+    _unpatch_google_adk()
+
+
 def _collect_exception_chain(exc: BaseException) -> List[BaseException]:
     """Walk ``__cause__`` / ``__context__`` and return the unique chain."""
     seen: List[BaseException] = []


### PR DESCRIPTION
# Pull Request

## Summary

Turns `openlayer.lib.init()` into an auto-instrumenting entry point. 

Calling `init()` with no extra arguments now detects every installed Openlayer-supported LLM SDK (`openai`, `anthropic`, `mistral`, `groq`, `gemini`, `oci`, `azure_content_understanding`, `litellm`, `portkey`, `google_adk`) and patches it so that every newly-constructed client is auto-traced. 

Existing `trace_<x>(client)` calls keep working. They're now also idempotent, so mixing auto-instrumentation with explicit wraps no longer double-wraps methods.

## Changes

- [x] Add `auto_instrument: bool | list[str] = True` parameter to `init()` in `src/openlayer/lib/tracing/tracer.py`.
Procedural (not stored in `_tracer_config`), evaluated fresh on every call. `False` short-circuits, a list patches
only that subset.
- [x] New module `src/openlayer/lib/integrations/_auto.py` with: `IntegrationSpec` dataclass, 10-entry `REGISTRY`,
`auto_instrument(targets)` and `unpatch_all()` orchestrators, plus shared `_patch_class_init` / `_unpatch_class_init`
 helpers that wrap a client class `__init__` via `functools.wraps` (so `__wrapped__` makes unpatch trivially reversible).
- [x] Per-integration `_patch_<x>()` / `_unpatch_<x>()` helpers added to 7 tracers (`openai_tracer.py`, `anthropic_tracer.py`, `mistral_tracer.py`, `groq_tracer.py`, `gemini_tracer.py`, `oci_tracer.py`, `azure_content_understanding_tracer.py`). Each wraps the SDK's client class `__init__` so new instances auto-call the
 existing `trace_<x>(client)` function (the `portkey_tracer.py` pattern). Covers sync + async + Azure variants where
applicable.
- [x] Bundled idempotency fix: every per-instance `trace_<x>(client)` in 9 tracer files gained a `getattr(client,
"_openlayer_patched", False) is True` entry guard plus a marker assignment before return. Pre-existing correctness
improvement — without it, calling `trace_openai(client)` twice nested the wrappers and double-counted every call. The
 strict `is True` comparison avoids false positives from `MagicMock`'s auto-attribute behavior (caught by the bedrock
 test suite).
- [x] `configure()` deprecated alias updated to default `auto_instrument=False` via `kwargs.setdefault`. Existing
`configure()` callers see no surprise patching on upgrade.
- [x] Re-export `auto_instrument` and `unpatch_all` from `openlayer.lib`.
- [x] `_is_installed` probes the full dotted path via `importlib.util.find_spec` (not just the top-level segment).
Fixes a namespace-package collision where `google.adk` falsely reported installed because `google.generativeai` was
installed under the same namespace.

## Context

[OPEN-10364: Make tracers init-based](https://linear.app/openlayer/issue/OPEN-10364/make-tracers-init-based)

## Testing

- [x] Manual testing

## Monitoring

- [x] No expected impact

## Notes

- **Behavior change**: anyone calling `init()` today (no args) will now auto-instrument every installed supported SDK
 on their next upgrade. This is the intended behavior — the "init-based" tracer model — but worth a callout in the
changelog. Users can opt out with `init(auto_instrument=False)` or by switching to the deprecated `configure()`
(which preserves the no-patching default).
- **Pre-existing client instances** created before `init()` are NOT retroactively auto-traced. The patch wraps the
class `__init__`, so only future construction goes through it. Class-method-level patching for catching pre-existing
instances is deferred.
- **Out of scope** (deferred to a follow-up): Bedrock auto-instrumentation (boto3 service-client shape needs a
different mechanism), LangChain auto-instrumentation (callback-based, no clean global hook), and the
`auto_instrument` env-var convenience.
- **Patch failure isolation**: if one integration's patcher raises, the orchestrator logs a warning and continues
with the rest. The returned `dict[str, bool]` reflects per-integration success.