### PR TITLE
feat(closes OPEN-10341): add native async runner for testset batches

### DIFF
--- a/src/openlayer/lib/core/base_model.py
+++ b/src/openlayer/lib/core/base_model.py
@@ -4,9 +4,10 @@ import os
 import abc
 import json
 import time
+import asyncio
 import inspect
 import argparse
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 from dataclasses import field, dataclass
 
 import pandas as pd
@@ -36,6 +37,12 @@ class OpenlayerModel(abc.ABC):
 
     It is more conventional to implement the `run` method.
 
+    ``run`` may be defined as either ``def run`` (called sequentially per row)
+    or ``async def run``. When ``run`` is async, ``run_batch_from_df`` will drive
+    rows concurrently with ``asyncio.gather``; pass ``max_workers > 1`` to enable
+    concurrent execution. Use async-native I/O (``httpx``, ``openai-async``, etc.)
+    inside an async ``run`` to actually benefit from concurrency.
+
     Refer to Openlayer's templates for examples of how to implement this class.
     """
 
@@ -59,6 +66,15 @@ class OpenlayerModel(abc.ABC):
             required=False,
             help="Custom arguments in format 'key1=value1,key2=value2'",
         )
+        parser.add_argument(
+            "--max-workers",
+            type=int,
+            default=None,
+            help=(
+                "Max concurrent rows when run() is async. "
+                "Defaults to 4 for async run, 1 for sync run."
+            ),
+        )
 
         # Parse the arguments
         args = parser.parse_args()
@@ -76,9 +92,12 @@ class OpenlayerModel(abc.ABC):
         return self.batch(
             dataset_path=args.dataset_path,
             output_dir=args.output_dir,
+            max_workers=args.max_workers,
         )
 
-    def batch(self, dataset_path: str, output_dir: str) -> None:
+    def batch(
+        self, dataset_path: str, output_dir: str, max_workers: Optional[int] = None
+    ) -> None:
         """Reads the dataset from a file and runs the model on it."""
         # Load the dataset into a pandas DataFrame
         fmt = "csv"
@@ -91,50 +110,125 @@ class OpenlayerModel(abc.ABC):
             raise ValueError(f"Unsupported dataset format: {dataset_path}")
 
         # Call the model's run_batch method, passing in the DataFrame
-        output_df, config = self.run_batch_from_df(df)
+        output_df, config = self.run_batch_from_df(df, max_workers=max_workers)
         self.write_output_to_directory(output_df, config, output_dir, fmt)
 
-    def run_batch_from_df(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, dict]:
-        """Function that runs the model and returns the result."""
-        # Ensure the 'output' column exists
-        if "output" not in df.columns:
-            df["output"] = None
+    def run_batch_from_df(
+        self, df: pd.DataFrame, max_workers: Optional[int] = None
+    ) -> Tuple[pd.DataFrame, dict]:
+        """Function that runs the model and returns the result.
 
-        # Get the signature of the 'run' method
+        If ``run`` is defined as ``async def run(...)``, rows are dispatched
+        concurrently with ``asyncio.gather`` gated by ``asyncio.Semaphore(max_workers)``.
+        ``max_workers`` defaults to 4 for an async ``run`` (writing `async def`
+        is the opt-in signal that interleaving is safe). For a synchronous
+        ``run``, rows are processed sequentially and ``max_workers`` must be 1.
+
+        A row's exception propagates and aborts the batch. For the async path,
+        ``asyncio.gather`` cancels in-flight siblings before re-raising.
+        """
         run_signature = inspect.signature(self.run)
+        valid_params = set(run_signature.parameters)
+        is_async = inspect.iscoroutinefunction(self.run)
 
-        for index, row in df.iterrows():
-            # Filter row_dict to only include keys that are valid parameters
-            # for the 'run' method
-            row_dict = row.to_dict()
-            filtered_kwargs = {
-                k: v for k, v in row_dict.items() if k in run_signature.parameters
-            }
+        if max_workers is None:
+            max_workers = 4 if is_async else 1
+        elif max_workers < 1:
+            raise ValueError("max_workers must be >= 1")
 
-            # Call the run method with filtered kwargs
-            output = self.run(**filtered_kwargs)
+        if max_workers > 1 and not is_async:
+            raise ValueError(
+                "max_workers > 1 requires an async `run` method. "
+                "Define `run` as `async def run(self, ...)` to enable "
+                "concurrent execution."
+            )
 
-            df.at[index, "output"] = output.output
+        for col in ("output", "steps", "latency", "cost", "tokens", "context"):
+            if col not in df.columns:
+                df[col] = None
 
-            for k, v in output.other_fields.items():
-                if k not in df.columns:
-                    df[k] = None
-                df.at[index, k] = v
+        rows = [
+            (
+                idx,
+                {k: v for k, v in row.to_dict().items() if k in valid_params},
+            )
+            for idx, row in df.iterrows()
+        ]
 
-            trace = tracer.get_current_trace()
-            if trace:
-                processed_trace, _ = tracer.post_process_trace(trace_obj=trace)
-                df.at[index, "steps"] = trace.to_dict()
-                if "latency" in processed_trace:
-                    df.at[index, "latency"] = processed_trace["latency"]
-                if "cost" in processed_trace:
-                    df.at[index, "cost"] = processed_trace["cost"]
-                if "tokens" in processed_trace:
-                    df.at[index, "tokens"] = processed_trace["tokens"]
-                if "context" in processed_trace:
-                    df.at[index, "context"] = processed_trace["context"]
+        if is_async:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                raise RuntimeError(
+                    "run_batch_from_df was called from inside a running event "
+                    "loop. Call `await self._run_rows_async(...)` directly "
+                    "from async code."
+                )
+            results = asyncio.run(self._run_rows_async(rows, max_workers))
+        else:
+            results = [
+                (idx, self.run(**kwargs), tracer.get_current_trace())
+                for idx, kwargs in rows
+            ]
 
-        config = {
+        for index, output, trace in results:
+            self._apply_row_result(df, index, output, trace)
+
+        return df, self._build_config(run_signature, df)
+
+    async def _run_rows_async(
+        self,
+        rows: List[Tuple[Any, Dict[str, Any]]],
+        max_workers: int,
+    ) -> List[Tuple[Any, RunReturn, Optional[Any]]]:
+        """Drive an async ``run`` over all rows with bounded concurrency.
+
+        The first row to raise causes ``asyncio.gather`` to cancel in-flight
+        siblings and re-raise the original exception.
+        """
+        sem = asyncio.Semaphore(max_workers)
+
+        async def _one(index: Any, kwargs: Dict[str, Any]):
+            async with sem:
+                output = await self.run(**kwargs)
+                return index, output, tracer.get_current_trace()
+
+        return await asyncio.gather(*(_one(i, k) for i, k in rows))
+
+    def _apply_row_result(
+        self,
+        df: pd.DataFrame,
+        index: Any,
+        output: RunReturn,
+        trace: Optional[Any],
+    ) -> None:
+        """Write a single row's output and trace fields into ``df`` in place."""
+        df.at[index, "output"] = output.output
+
+        for k, v in output.other_fields.items():
+            if k not in df.columns:
+                df[k] = None
+            df.at[index, k] = v
+
+        if trace:
+            processed_trace, _ = tracer.post_process_trace(trace_obj=trace)
+            df.at[index, "steps"] = trace.to_dict()
+            if "latency" in processed_trace:
+                df.at[index, "latency"] = processed_trace["latency"]
+            if "cost" in processed_trace:
+                df.at[index, "cost"] = processed_trace["cost"]
+            if "tokens" in processed_trace:
+                df.at[index, "tokens"] = processed_trace["tokens"]
+            if "context" in processed_trace:
+                df.at[index, "context"] = processed_trace["context"]
+
+    def _build_config(
+        self, run_signature: inspect.Signature, df: pd.DataFrame
+    ) -> Dict[str, Any]:
+        """Build the config dict returned alongside the output DataFrame."""
+        config: Dict[str, Any] = {
             "outputColumnName": "output",
             "inputVariableNames": list(run_signature.parameters.keys()),
             "metadata": {
@@ -154,7 +248,7 @@ class OpenlayerModel(abc.ABC):
         for k, v in self.custom_args.items():
             config["metadata"][k] = v
 
-        return df, config
+        return config
 
     def write_output_to_directory(
         self,


### PR DESCRIPTION
# Pull Request

## Summary

Adds native async support to `OpenlayerModel.run_batch_from_df` so that customers whose per-row work hits slow APIs
(~5s/row) can run testset batches concurrently instead of strictly sequentially. 

Users opt in by defining `run` as `async def run(...)`; the framework then drives rows through `asyncio.gather` gated by a semaphore. Sync `run` keeps today's behavior byte-for-byte.

## Changes

- [x] `run` may now be defined as `async def run(...)`. When it is, `run_batch_from_df` dispatches rows concurrently
via `asyncio.gather` + `asyncio.Semaphore(max_workers)`.
- [x] New `max_workers` kwarg on `run_batch_from_df` and `batch`, plus `--max-workers` on the CLI. Default resolves to
**4 for async `run`, 1 for sync `run`** — writing `async def` is the opt-in signal that interleaving is safe.
- [x] `max_workers > 1` with a sync `run` raises `ValueError` rather than silently ignoring it.
- [x] Per-row exceptions still propagate and abort the batch (fail-fast, same as today). For the async path,
`asyncio.gather` cancels in-flight siblings before re-raising.
- [x] Extracted `_run_rows_async`, `_apply_row_result`, and `_build_config` helpers so the row bookkeeping is shared
between the sync and async paths.

## Context

[OPEN-10341: Add native async runner for testset batches](https://linear.app/openlayer/issue/OPEN-10341/add-native-async-runner-for-testset-batches)

## Testing

- [x] Manual testing

## Monitoring

- [x] No expected impact

## Notes

- **Backwards compatible**: existing sync `run` implementations behave identically. Same sequential code path, same
fail-fast semantics, no executor or asyncio overhead.
- **Customer-facing usage**: if a customer's `openlayer_run.py` already defines `async def run(...)`, they get 4-way
concurrency automatically next release. To override, append `--max-workers N` to the `batchCommand` in
`openlayer.json`.