### PR TITLE
fix(tracing): harden offline buffer for concurrency and high volume

### DIFF
--- a/src/openlayer/lib/tracing/tracer.py
+++ b/src/openlayer/lib/tracing/tracer.py
@@ -384,7 +384,9 @@ class OfflineBuffer:
         self.buffer_path = Path(
             buffer_path or os.path.expanduser("~/.openlayer/buffer")
         )
-        self.max_buffer_size = max_buffer_size or 1000
+        # Use an explicit None check so a caller-supplied 0 (buffer nothing) is
+        # respected rather than falling through to the default.
+        self.max_buffer_size = 1000 if max_buffer_size is None else max_buffer_size
         self._lock = threading.RLock()
 
         # Create buffer directory if it doesn't exist
@@ -408,19 +410,41 @@ class OfflineBuffer:
         Returns:
             True if successfully stored, False otherwise
         """
+        if self.max_buffer_size <= 0:
+            logger.debug("Offline buffer max_buffer_size <= 0; not storing trace")
+            return False
         try:
             with self._lock:
-                # Check buffer size limit
-                existing_files = list(self.buffer_path.glob("trace_*.json"))
-                if len(existing_files) >= self.max_buffer_size:
-                    # Remove oldest file to make room
-                    oldest_file = min(existing_files, key=lambda f: f.stat().st_mtime)
-                    oldest_file.unlink()
-                    logger.debug("Removed oldest buffered trace: %s", oldest_file)
+                # Trim the buffer so that, after adding one file, we stay within
+                # the limit. Removing the whole excess in one batch (rather than
+                # a single file per store) keeps the buffer bounded even when
+                # multiple processes share the directory and evict concurrently;
+                # otherwise each writer drops one file while many add and the cap
+                # is never enforced.
+                existing: List[Tuple[float, Path]] = []
+                for existing_file in self.buffer_path.glob("trace_*.json"):
+                    try:
+                        existing.append((existing_file.stat().st_mtime, existing_file))
+                    except OSError:
+                        # File vanished (a concurrent writer evicted it); skip it.
+                        continue
+                if len(existing) >= self.max_buffer_size:
+                    existing.sort(key=lambda pair: pair[0])  # oldest first
+                    remove_count = len(existing) - self.max_buffer_size + 1
+                    for _, old_file in existing[:remove_count]:
+                        try:
+                            old_file.unlink()
+                        except OSError:
+                            # Best effort - another writer may have removed it.
+                            pass
+                    logger.debug("Evicted %d old buffered trace(s)", remove_count)
 
-                # Create filename with timestamp and unique suffix
+                # Create filename with timestamp and unique suffix. Use the full
+                # UUID (not a truncated slice) so filenames stay unique even at
+                # high volume within a single process: worker threads share a
+                # PID, so a truncated id could collide and overwrite a trace.
                 timestamp = int(time.time() * 1000)  # milliseconds
-                unique_id = str(uuid.uuid4())[:8]  # Short unique identifier
+                unique_id = str(uuid.uuid4())
                 filename = f"trace_{timestamp}_{os.getpid()}_{unique_id}.json"
                 file_path = self.buffer_path / filename
 
@@ -534,19 +558,25 @@ class OfflineBuffer:
         Returns:
             Number of traces removed
         """
+        removed = 0
         try:
             with self._lock:
                 trace_files = list(self.buffer_path.glob("trace_*.json"))
-                count = len(trace_files)
 
                 for file_path in trace_files:
-                    file_path.unlink(missing_ok=True)
+                    # Isolate each removal so one failure does not abort the rest
+                    # and the returned count reflects what was actually removed.
+                    try:
+                        file_path.unlink(missing_ok=True)
+                        removed += 1
+                    except OSError as e:
+                        logger.error("Failed to remove buffered trace %s: %s", file_path, e)
 
-                logger.info("Cleared %d traces from offline buffer", count)
-                return count
+                logger.info("Cleared %d traces from offline buffer", removed)
+                return removed
         except Exception as e:
             logger.error("Failed to clear buffer: %s", e)
-            return 0
+            return removed
 
 
 # Global offline buffer instance
@@ -1622,6 +1652,10 @@ def replay_buffered_traces(
             "error": "No Openlayer client available",
         }
 
+    # Always make at least one attempt, even if a caller passes 0 or a negative,
+    # so replay never silently no-ops while leaving traces buffered.
+    attempts = max(1, max_retries)
+
     buffered_traces = offline_buffer.get_buffered_traces()
     total_traces = len(buffered_traces)
     success_count = 0
@@ -1640,7 +1674,7 @@ def replay_buffered_traces(
         last_error = None
 
         # Retry logic
-        for attempt in range(max_retries):
+        for attempt in range(attempts):
             try:
                 response = client.inference_pipelines.data.stream(
                     inference_pipeline_id=inference_pipeline_id,
@@ -1680,7 +1714,7 @@ def replay_buffered_traces(
                 )
 
                 # If this is the last attempt, mark as failed
-                if attempt == max_retries - 1:
+                if attempt == attempts - 1:
                     failure_count += 1
                     failed_traces.append(
                         {

--- a/tests/test_offline_buffering.py
+++ b/tests/test_offline_buffering.py
@@ -153,6 +153,44 @@ class TestOfflineBuffer:
         traces = self.buffer.get_buffered_traces()
         assert len(traces) == 0
 
+    def test_store_trace_max_buffer_size_zero(self):
+        """A max_buffer_size of 0 stores nothing."""
+        buf = OfflineBuffer(buffer_path=str(Path(self.temp_dir) / "zero_buf"), max_buffer_size=0)
+        assert buf.max_buffer_size == 0
+        assert buf.store_trace({"inferenceId": "x"}, {}, "p") is False
+        assert len(buf.get_buffered_traces()) == 0
+
+    def test_store_trace_batch_eviction(self):
+        """Storing into an over-capacity backlog trims it down to the cap in one
+        store, rather than dropping only a single file."""
+        # Seed 10 files with a large cap so no eviction happens yet.
+        big = OfflineBuffer(buffer_path=str(self.buffer_path), max_buffer_size=100)
+        for i in range(10):
+            big.store_trace({"inferenceId": f"b-{i}"}, {}, "p")
+        assert len(list(self.buffer_path.glob("trace_*.json"))) == 10
+
+        # A buffer over the same dir with a small cap must trim the whole backlog
+        # on the next store. Dropping one file per store is what let concurrent
+        # writers blow past the cap.
+        small = OfflineBuffer(buffer_path=str(self.buffer_path), max_buffer_size=3)
+        small.store_trace({"inferenceId": "newest"}, {}, "p")
+        assert len(list(self.buffer_path.glob("trace_*.json"))) == 3
+
+    def test_clear_buffer_resilient_to_failed_removal(self):
+        """clear_buffer keeps going when one entry can't be removed and reports
+        the count actually removed."""
+        self.buffer.store_trace({"inferenceId": "a"}, {}, "p")
+        self.buffer.store_trace({"inferenceId": "b"}, {}, "p")
+        # A directory matching the trace glob cannot be unlink()'d, simulating one
+        # un-removable entry without mocking the filesystem.
+        (self.buffer_path / "trace_999_0_undeletable.json").mkdir()
+
+        removed = self.buffer.clear_buffer()
+
+        assert removed == 2
+        # The directory survives; the two real trace files are gone.
+        assert len(list(self.buffer_path.glob("trace_*.json"))) == 1
+
 
 class TestTracerConfiguration:
     """Test cases for tracer configuration with offline buffering."""
@@ -420,6 +458,28 @@ class TestBufferUtilityFunctions:
         # Check that trace is still in buffer
         traces = buffer.get_buffered_traces()
         assert len(traces) == 1
+
+    @patch("openlayer.lib.tracing.tracer._get_client")
+    def test_replay_buffered_traces_max_retries_zero(self, mock_get_client: Mock) -> None:
+        """max_retries=0 still attempts each trace once instead of silently no-op."""
+        mock_client = Mock()
+        mock_client.inference_pipelines.data.stream.side_effect = Exception("API Error")
+        mock_get_client.return_value = mock_client
+
+        init(offline_buffer_enabled=True, offline_buffer_path=self.temp_dir)
+        buffer = _get_offline_buffer()
+        assert buffer is not None
+        buffer.store_trace({"inferenceId": "z1", "output": "o"}, {"output_column_name": "output"}, "test-pipeline")
+
+        failure_calls: List[Tuple[Dict[str, Any], Dict[str, Any], Exception]] = []
+        result = replay_buffered_traces(
+            max_retries=0,
+            on_replay_failure=lambda td, cfg, err: failure_calls.append((td, cfg, err)),
+        )
+
+        assert mock_client.inference_pipelines.data.stream.call_count == 1
+        assert result["failure_count"] == 1
+        assert len(failure_calls) == 1
 
     def test_replay_buffered_traces_disabled(self):
         """Test replay when buffer is disabled."""


### PR DESCRIPTION
## Summary

Hardens the offline trace buffer against **multi-process / multi-thread** use and **high volume**, where it could silently lose data or grow unbounded past its configured cap. These issues were found while porting the feature to the TypeScript SDK and validating it end-to-end (worker threads + child processes + real HTTP); the same root causes exist here. (Note: the `configure()` "replace-all" footgun is already fixed on `main` via the merge-semantics `init()`, so it is not included.)

## Fixes

1. **Eviction cap not enforced across processes** — `store_trace` removed only one oldest file per call. With multiple processes sharing the default `~/.openlayer/buffer`, concurrent writers each drop one while many add, so the cap is never enforced (reproduced: 4 processes × 800 writes to a cap-200 buffer left 220+ files). Now evicts the **full excess in one batch** down to `max_buffer_size`. Also stats each candidate defensively, so a file removed by another writer mid-scan no longer raises and aborts the store (which previously **dropped that trace**).

2. **Filename collisions at high volume** — filenames used `str(uuid.uuid4())[:8]` (32 bits). Across processes the PID disambiguates, but **worker threads share a PID**, so birthday collisions become likely at tens of thousands of buffered traces → silent overwrite. Now uses the **full UUID** (122 bits).

3. **`max_buffer_size=0` coerced to 1000** — `max_buffer_size or 1000` treated an explicit `0` as falsy. Now uses an explicit `None` check and honors `0` (store nothing).

4. **`clear_buffer` aborted on the first failed unlink** and could mis-report the count (returned 0 even after deleting some). Now isolates each removal and returns the count actually removed.

5. **`replay_buffered_traces(max_retries=0)` was a silent no-op** — `range(0)` never ran the loop, so traces stayed buffered with a misleading 0/0 result. Now always attempts each trace at least once.

## What is NOT changed

- `get_buffered_traces` already uses `sorted(key=...)` (one `stat` per file) and per-file `try/except`, so no perf/robustness change was needed there (the TS port needed it because JS sort calls the comparator repeatedly).
- Replay still relies on the SDK client's built-in retry/backoff between attempts (unchanged).

## Tests

Adds 4 regression tests in `tests/test_offline_buffering.py` (batch eviction, `max_buffer_size=0`, resilient `clear_buffer`, `replay(max_retries=0)`) — each verified to **fail on the prior implementation** and pass with the fix. Full tracer test suite (`test_offline_buffering`, `test_tracer_configuration`, `test_tracing_core`) passes (83 tests). `ruff check`/`ruff format` clean; `mypy` introduces no new errors vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)