### PR TITLE
fix(closes OPEN-12012): upload batch inferences presigned URL bug

### DIFF
--- a/src/openlayer/lib/data/batch_inferences.py
+++ b/src/openlayer/lib/data/batch_inferences.py
@@ -42,18 +42,19 @@ def upload_batch_inferences(
 
     # Write dataset and config to temp directory
     with tempfile.TemporaryDirectory() as tmp_dir:
-        # If DataFrame is provided, convert it to Arrow Table and write it using IPC
-        # writer
-        if dataset_df is not None:
-            temp_file_path = f"{tmp_dir}/dataset.arrow"
-            pa_table = pa.Table.from_pandas(dataset_df)
-            pa_schema = pa_table.schema
+        # Both inputs are uploaded as an Arrow IPC stream. The object key is already
+        # committed to `.arrow` by the presigned URL above, and the backend dispatches
+        # on that extension when it reads the batch back — so a CSV has to be
+        # converted here rather than uploaded as-is.
+        if dataset_df is None:
+            dataset_df = pd.read_csv(dataset_path)
 
-            with pa.ipc.RecordBatchStreamWriter(temp_file_path, pa_schema) as writer:
-                writer.write_table(pa_table, max_chunksize=16384)
-        else:
-            object_name = f"batch_data_{time.time()}_{inference_pipeline_id}.csv"
-            temp_file_path = dataset_path
+        temp_file_path = f"{tmp_dir}/dataset.arrow"
+        pa_table = pa.Table.from_pandas(dataset_df)
+        pa_schema = pa_table.schema
+
+        with pa.ipc.RecordBatchStreamWriter(temp_file_path, pa_schema) as writer:
+            writer.write_table(pa_table, max_chunksize=16384)
 
         # camelCase the config
         config = maybe_transform(config, data_stream_params.Config)


### PR DESCRIPTION
# Pull Request

## Summary

Fixes `upload_batch_inferences(dataset_path=...)` uploading CSV bytes to an object key ending in `.arrow`, which made every batch fail asynchronously on the backend while the client reported success.

The presigned URL was minted before the input type was known, hardcoding a `.arrow` object key. The `dataset_path` branch then reassigned `object_name` to `.csv` — too late, and dead code besides, since the storage destination comes from the already-signed URL (for FS storage, the signed token payload), not from the multipart filename field. The backend dispatches on that `.arrow` extension and read the CSV through `read_arrow_ipc`, raising `ArrowInvalid` inside the RQ worker. `POST /inference-pipelines/{id}/data` only validates that the blob exists, so it returned `200` and the SDK logged `Success! Uploaded batch inferences`.

Both inputs now converge on the Arrow IPC path, so the uploaded bytes always match the key the URL was signed for.

## Changes

- [x] `batch_inferences.py`: convert a `dataset_path` CSV via `pd.read_csv` and write it as an Arrow IPC stream, so `dataset_df` and `dataset_path` share one upload path
- [x] `batch_inferences.py`: remove the dead `object_name` reassignment to `.csv` that could never affect the upload destination

## Context

[OPEN-12012: Upload batch inferences presigned URL bug](https://linear.app/openlayer/issue/OPEN-12012/upload-batch-inferences-presigned-url-bug)

## Testing

- [x] Manual testing

## Monitoring

- [x] No expected impact